### PR TITLE
Add comprehensive MkDocs documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ __pycache__/
 *.pyo
 .env
 venv/
+site/

--- a/README.md
+++ b/README.md
@@ -2,68 +2,47 @@
 
 A collection of custom skills that extend Claude's capabilities with specialized workflows, methods, and domain knowledge.
 
-## What Are Skills?
+📚 **[View Full Documentation](https://robertguss.github.io/claude-skills/)**
 
-Skills are modular packages that transform Claude from a general-purpose assistant into a specialized collaborator. Each skill contains instructions, reference documentation, and templates for specific domains.
-
-## Installation
+## Quick Start
 
 ### Claude Code (CLI)
-
-Reference skills directly in your project's `CLAUDE.md` or global `~/.claude/CLAUDE.md`:
 
 ```markdown
 # CLAUDE.md
 
-## Skills
-
-When brainstorming, read and follow `/path/to/claude-skills/brainstorm/SKILL.md`.
+When brainstorming, read and follow /path/to/claude-skills/brainstorm/SKILL.md.
 ```
 
 ### Claude.ai (Web/Mobile/Desktop)
 
-1. Package the skill: `python build.py <skill-name>`
-2. Open Claude.ai → Settings → Skills
-3. Upload the `.skill` file from `dist/`
+```bash
+python build.py brainstorm
+# Upload dist/brainstorm.skill to Claude.ai → Settings → Skills
+```
 
 ## Available Skills
 
-### Standalone Skills
+| Category | Skills | Description |
+|----------|--------|-------------|
+| **Standalone** | [brainstorm](brainstorm/) | Multi-session ideation with 25+ thinking methods |
+| **Book Factory** | 6 skills | Full pipeline from idea to chapter architecture |
+| **Ebook Factory** | 2 skills | Focused ebook creation pipeline |
+| **Writing** | 2 skills | Voice capture and ghost writing |
 
-| Skill                     | Description                                                                                                     |
-| ------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| [brainstorm](brainstorm/) | Collaborative multi-session brainstorming with versioned documents, 25+ thinking methods, and decision tracking |
+## Documentation
 
-### Non-Fiction Book Factory
+- [Getting Started](https://robertguss.github.io/claude-skills/getting-started/)
+- [All Skills](https://robertguss.github.io/claude-skills/skills/)
+- [Developer Guide](https://robertguss.github.io/claude-skills/developer-guide/)
 
-A pipeline of skills for developing nonfiction books from idea to architecture. See [full documentation](non-fiction-book-factory/).
+## Local Documentation
 
-| Skill                   | Description                                                     |
-| ----------------------- | --------------------------------------------------------------- |
-| book-ideation           | Develop raw ideas into structured Book Concept Documents        |
-| book-idea-validator     | Stress-test concepts against existing research (Go/Revise/Kill) |
-| book-market-research    | Assess commercial viability for Amazon KDP                      |
-| book-architect          | Design structural and emotional architecture for drafting       |
-| book-research-assistant | Plan, orchestrate, and validate deep research before outlining  |
-| chapter-architect       | Plan individual chapters at beat-level granularity for drafting |
-
-### Writing Skills
-
-A pipeline for capturing and replicating a writer's authentic voice. See [full documentation](writing/).
-
-| Skill                 | Description                                                                |
-| --------------------- | -------------------------------------------------------------------------- |
-| writing-dna-discovery | Capture voice patterns through collaborative interview and sample analysis |
-| ghost-writer          | Produce first drafts at ~80% voice accuracy using Voice DNA Documents      |
-
-### Ebook Factory
-
-A pipeline of skills for creating ebooks — shorter, concentrated solutions optimized for speed-to-value. See [full documentation](ebook-factory/).
-
-| Skill                     | Description                                                                |
-| ------------------------- | -------------------------------------------------------------------------- |
-| ebook-discovery           | Surface ebook ideas from content, expertise, and archives (11 entry modes) |
-| ebook-concept-development | Develop ideas into structured concepts ready for architecture              |
+```bash
+pip install -r requirements-docs.txt
+mkdocs serve
+# Visit http://localhost:8000
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -36,12 +36,25 @@ python build.py brainstorm
 - [All Skills](https://robertguss.github.io/claude-skills/skills/)
 - [Developer Guide](https://robertguss.github.io/claude-skills/developer-guide/)
 
-## Local Documentation
+## Development
+
+This project uses [uv](https://docs.astral.sh/uv/) for dependency management and [just](https://github.com/casey/just) as a command runner.
 
 ```bash
-pip install -r requirements-docs.txt
-mkdocs serve
-# Visit http://localhost:8000
+# Install dependencies
+just install
+
+# Serve docs locally at http://localhost:8000
+just docs-serve
+
+# Deploy docs to GitHub Pages
+just docs-deploy
+
+# Package a skill
+just package brainstorm
+
+# See all commands
+just
 ```
 
 ## License

--- a/docs/concepts/handoffs.md
+++ b/docs/concepts/handoffs.md
@@ -1,0 +1,205 @@
+# Handoffs
+
+The structured documents that pass between skills in a pipeline.
+
+---
+
+## What Are Handoffs?
+
+When one skill completes its work, it produces a **handoff document**—a structured output that contains everything the next skill needs to continue. Handoffs are the connective tissue of pipelines.
+
+Think of it like a relay race: the baton (handoff document) carries all the context so the next runner (skill) can continue without starting over.
+
+---
+
+## Anatomy of a Handoff
+
+A typical handoff document contains:
+
+| Section | Purpose |
+|---------|---------|
+| **Summary** | Quick orientation on what this represents |
+| **Core Elements** | The substantive content the next skill needs |
+| **Decisions Made** | What was decided, with reasoning |
+| **Recommendations** | Guidance for the downstream skill |
+| **Concerns/Flags** | Issues the next skill should address |
+| **Readiness Status** | Whether this is complete or partial |
+
+---
+
+## Example: Book Concept Document
+
+The `book-ideation` skill produces a Book Concept Document as its handoff:
+
+```markdown
+# Book Concept Document: [Title]
+
+## Summary
+[2-3 sentences describing the book]
+
+## The Eight Elements
+
+### 1. The Reader
+[Specific description of who this is for]
+
+### 2. The Transformation
+Before: [Where reader starts]
+After: [Where reader ends up]
+
+### 3. The Core Thesis
+[The one big idea someone can disagree with]
+
+### 4. The Author Angle
+[Why this author writes this book]
+
+### 5. The Stakes
+[Why it matters, why now]
+
+### 6. The Key Concepts
+[3-7 major ideas supporting the thesis]
+
+### 7. The Enemy
+[What this book argues against]
+
+### 8. The Promise
+[One sentence: what does the reader get?]
+
+## Readiness
+[Ready for validation / Needs more work on X]
+
+## Notes for Downstream
+[Any context the next skill should know]
+```
+
+This document then feeds into `book-idea-validator` and `book-market-research`.
+
+---
+
+## Handoff Patterns
+
+### One-to-One
+
+Simple handoff to the next skill:
+
+```mermaid
+flowchart LR
+    A[book-ideation] -->|Book Concept Doc| B[book-idea-validator]
+```
+
+### One-to-Many
+
+Some handoffs feed multiple downstream skills:
+
+```mermaid
+flowchart LR
+    A[book-ideation] -->|Book Concept Doc| B[book-idea-validator]
+    A -->|Book Concept Doc| C[book-market-research]
+```
+
+### Accumulating Handoffs
+
+Downstream skills often receive multiple handoffs:
+
+```mermaid
+flowchart LR
+    A[book-ideation] -->|Concept Doc| D[book-architect]
+    B[book-idea-validator] -->|Validation Report| D
+    C[book-market-research] -->|Market Report| D
+```
+
+---
+
+## Readiness Criteria
+
+Each handoff has explicit readiness criteria—conditions that must be met before the document is ready for downstream use.
+
+### Example: Book Concept Document Readiness
+
+The Book Concept Document is ready when:
+
+- [ ] All eight elements are developed (not just listed)
+- [ ] Reader can be described as a specific person
+- [ ] Transformation has concrete before/after states
+- [ ] Thesis is a claim someone can disagree with
+- [ ] Promise is one compelling sentence
+
+### Partial Handoffs
+
+Sometimes work isn't complete but progress needs to continue:
+
+```markdown
+## Readiness: Partial
+
+Ready for validation: Yes
+Concerns: The Author Angle is underdeveloped—validator
+should flag if this causes credibility concerns.
+```
+
+The downstream skill knows what to watch for.
+
+---
+
+## Handoff vs. Version Document
+
+| Aspect | Handoff Document | Version Document |
+|--------|------------------|------------------|
+| Purpose | Pass to next skill | Continue within skill |
+| Audience | Downstream skill | Same skill, next session |
+| Content | Final outputs | Working state |
+| Versioning | Single document | v1, v2, v3... |
+
+A session might produce multiple version documents but culminate in one handoff document when the skill's work is complete.
+
+---
+
+## Common Handoff Documents
+
+| Skill | Produces | Consumed By |
+|-------|----------|-------------|
+| book-ideation | Book Concept Document | book-idea-validator, book-market-research |
+| book-idea-validator | Validation Report | book-market-research, book-architect |
+| book-market-research | Market Research Report | book-architect |
+| book-architect | Architecture Documents, Research Gaps | book-research-assistant, chapter-architect |
+| book-research-assistant | Research Synthesis | chapter-architect |
+| writing-dna-discovery | Voice DNA Document | ghost-writer |
+| ebook-discovery | Discovery Tracker, Handoff Summary | ebook-concept-development |
+
+---
+
+## Creating Good Handoffs
+
+### Do
+
+- **Include reasoning, not just conclusions** — Downstream skills benefit from understanding why
+- **Flag concerns explicitly** — Don't hide problems; surface them for the next skill
+- **Meet readiness criteria** — Don't handoff incomplete work without marking it partial
+- **Use consistent structure** — Templates enable reliable consumption
+
+### Don't
+
+- **Dump raw session content** — Handoffs are curated, not transcripts
+- **Assume context** — The downstream skill may be a fresh Claude instance
+- **Skip the summary** — Quick orientation helps the next skill engage faster
+
+---
+
+## When Handoffs Flow Backward
+
+Sometimes downstream skills discover problems that require upstream revision:
+
+```mermaid
+flowchart LR
+    A[book-architect] -->|Architecture Feedback| B[book-ideation]
+    A -->|Research Gaps| C[book-research-assistant]
+    C -->|Thesis Tension| A
+```
+
+This feedback loop ensures quality: if research reveals the thesis is flawed, that information flows back to architecture for structural revision.
+
+---
+
+## Related Concepts
+
+- [Pipelines](pipelines.md) — How skills chain together
+- [Session Continuity](session-continuity.md) — Working within a skill across time
+- [Modes & Registers](modes-and-registers.md) — Adapting to different situations

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -1,0 +1,88 @@
+# Concepts
+
+Understanding the key ideas behind how Claude Skills work.
+
+---
+
+## Core Concepts
+
+<div class="grid cards" markdown>
+
+-   :material-pipe:{ .lg .middle } **[Pipelines](pipelines.md)**
+
+    ---
+
+    How skills chain together in sequences, with structured handoffs between stages.
+
+-   :material-clock-outline:{ .lg .middle } **[Session Continuity](session-continuity.md)**
+
+    ---
+
+    How skills maintain context across sessions spanning days or weeks.
+
+-   :material-swap-horizontal:{ .lg .middle } **[Handoffs](handoffs.md)**
+
+    ---
+
+    The structured documents that pass between skills in a pipeline.
+
+-   :material-toggle-switch:{ .lg .middle } **[Modes & Registers](modes-and-registers.md)**
+
+    ---
+
+    Different operating modes skills offer for different situations.
+
+</div>
+
+---
+
+## Why These Concepts Matter
+
+Skills aren't just instruction sets—they're designed systems with specific patterns that make them powerful:
+
+| Concept | Problem It Solves |
+|---------|-------------------|
+| **Pipelines** | Complex work needs specialists, not generalists |
+| **Session Continuity** | Creative work happens over time, not in one sitting |
+| **Handoffs** | Each specialist needs clear input from the previous |
+| **Modes** | Different situations need different approaches |
+
+---
+
+## How They Work Together
+
+```mermaid
+flowchart TB
+    subgraph Pipeline["Pipeline (e.g., Book Factory)"]
+        A[Skill 1: Ideation] -->|Handoff Doc| B[Skill 2: Validation]
+        B -->|Handoff Doc| C[Skill 3: Architecture]
+    end
+
+    subgraph Continuity["Session Continuity"]
+        S1[Session 1] -->|v1 doc| S2[Session 2]
+        S2 -->|v2 doc| S3[Session 3]
+    end
+
+    subgraph Modes["Modes"]
+        M1[Deep Mode]
+        M2[Quick Mode]
+        M3[Connected Mode]
+        M4[Clean-Slate Mode]
+    end
+```
+
+A typical workflow combines all these concepts:
+
+1. You start a **pipeline** at the first skill
+2. Across multiple **sessions**, you develop the work (continuity via versioned documents)
+3. You choose appropriate **modes** based on your situation
+4. When ready, the skill produces a **handoff document** for the next skill
+
+---
+
+## Next Steps
+
+- [:octicons-arrow-right-24: Pipelines](pipelines.md) — Start here to understand skill sequences
+- [:octicons-arrow-right-24: Session Continuity](session-continuity.md) — How work persists across time
+- [:octicons-arrow-right-24: Handoffs](handoffs.md) — What passes between skills
+- [:octicons-arrow-right-24: Modes & Registers](modes-and-registers.md) — Adapting to different situations

--- a/docs/concepts/modes-and-registers.md
+++ b/docs/concepts/modes-and-registers.md
@@ -1,0 +1,201 @@
+# Modes & Registers
+
+Different operating modes skills offer for different situations.
+
+---
+
+## Why Modes?
+
+Not every session is the same. Sometimes you have two hours for deep exploration. Sometimes you have fifteen minutes and need quick progress. Skills adapt to these different situations through **modes**—configurable ways of operating.
+
+---
+
+## Common Mode Types
+
+### Session Energy Modes
+
+Many skills ask about session energy at the start:
+
+| Mode | Best For | Behavior |
+|------|----------|----------|
+| **Deep exploration** | Long sessions, open-ended thinking, divergent work | Freely use methods, allow tangents, embrace ambiguity, end with synthesis |
+| **Quick progress** | Short sessions, need decisions, move forward | Clear scope upfront, primarily convergent methods, time-boxed, end with next actions |
+
+**Example prompt:**
+```
+Claude: Deep exploration today or quick progress?
+```
+
+### Context Awareness Modes
+
+Some skills offer different levels of context awareness:
+
+| Mode | Best For | Behavior |
+|------|----------|----------|
+| **Connected** | Building on existing work, ensuring consistency | Cross-references other projects: "This relates to your thinking on X" |
+| **Clean-slate** | Genuinely new territory, avoiding anchoring bias | No references to other projects; fresh perspective |
+
+**When to use clean-slate:**
+- Past approaches aren't working
+- You want to avoid confirmation bias
+- The topic is genuinely new territory
+
+### Session Types
+
+Some skills have distinct session types:
+
+| Type | Purpose | Example |
+|------|---------|---------|
+| **Quick Assessment** | Fast, single-session work | Market research qualitative scan |
+| **Deep Dive** | Thorough, multi-session work | Market research with quantitative data |
+| **Quick Capture** | Rapid idea capture when time is short | Brainstorm idea dump in 5 minutes |
+
+---
+
+## Author Intent (Market Research)
+
+The book-market-research skill interprets viability scores based on author intent:
+
+| Intent | Description | Score Interpretation |
+|--------|-------------|---------------------|
+| **Income** | Book must generate revenue | Score is decisive |
+| **Authority** | Book is a credential | Moderate score acceptable |
+| **Passion/Legacy** | "This book needs to exist" | Low score = proceed with eyes open |
+| **Lead Generation** | Funnel for services | Platform fit matters more |
+| **Audience Service** | Serving existing followers | Platform strength > market size |
+
+The same viability score means different things depending on why you're writing.
+
+---
+
+## Research Modes
+
+Research-oriented skills often have phases:
+
+| Phase | Focus | Output |
+|-------|-------|--------|
+| **Planning** | Generate prompts, identify gaps | Research prompts |
+| **Validation** | Review outputs, render verdicts | Quality assessments |
+| **Synthesis** | Consolidate findings | Summary documents |
+
+---
+
+## Operating Registers
+
+Beyond explicit modes, skills adapt their **register**—how they communicate and operate:
+
+### Collaboration Register
+
+How Claude engages with your ideas:
+
+| Register | Behavior |
+|----------|----------|
+| **Supportive** | Develops and builds on your ideas |
+| **Challenging** | Pushes back, asks hard questions, plays devil's advocate |
+| **Neutral** | Presents options without strong opinions |
+
+Most skills default to **challenging** because that's where value lives—but you can request a different register.
+
+### Depth Register
+
+How thoroughly Claude explores:
+
+| Register | Behavior |
+|----------|----------|
+| **Surface** | Quick overview, main points only |
+| **Standard** | Balanced exploration |
+| **Deep** | Thorough analysis, edge cases, nuances |
+
+### Formality Register
+
+How structured the output is:
+
+| Register | Behavior |
+|----------|----------|
+| **Conversational** | Informal, flowing discussion |
+| **Structured** | Clear sections, tables, bullet points |
+| **Formal** | Document-ready, professional tone |
+
+---
+
+## Selecting Modes
+
+### At Session Start
+
+Most mode selection happens at session start:
+
+```
+Claude: A few questions before we begin:
+        1. New project or continuing?
+        2. Deep exploration or quick progress today?
+        3. Connected mode or clean-slate?
+```
+
+### Mid-Session Adjustments
+
+You can adjust modes during a session:
+
+```
+You: Let's switch to quick progress mode—I need to wrap up soon.
+
+Claude: Got it. Switching to quick progress. Let me summarize where we are
+        and identify the key decision we should make before you go.
+```
+
+### When Mode Isn't Specified
+
+If you don't specify a mode, skills typically:
+
+1. Use sensible defaults (often connected mode, moderate depth)
+2. Adapt based on context (long conversation = deep, short = quick)
+3. Ask if the choice significantly impacts the session
+
+---
+
+## Mode Impact on Output
+
+The same skill can produce very different outputs based on mode:
+
+### Brainstorm: Deep Exploration
+
+```
+Session: 45 minutes
+Output: 3 pages of explored territory
+Methods: SCAMPER, Random Stimulus, First Principles
+Decisions: None yet—exploring
+Next: "Sit with this before deciding"
+```
+
+### Brainstorm: Quick Progress
+
+```
+Session: 15 minutes
+Output: 1 page with clear decision
+Methods: Elimination Rounds
+Decisions: 2 logged with reasoning
+Next: Specific action items
+```
+
+---
+
+## Best Practices
+
+### Do
+
+- **Be honest about your time and energy** — The right mode makes sessions more effective
+- **Experiment with modes** — Try clean-slate if you're stuck; try deep if you're rushing
+- **Request register changes** — "Push back more" or "Be more supportive" are valid requests
+
+### Don't
+
+- **Default to deep always** — Quick progress mode is valuable, not inferior
+- **Force a mode that doesn't fit** — If you have 10 minutes, don't pretend you have an hour
+- **Ignore mode recommendations** — Skills suggest modes for reasons
+
+---
+
+## Related Concepts
+
+- [Session Continuity](session-continuity.md) — How work persists across time
+- [Pipelines](pipelines.md) — How skills chain together
+- [Handoffs](handoffs.md) — Documents that pass between skills

--- a/docs/concepts/modes-and-registers.md
+++ b/docs/concepts/modes-and-registers.md
@@ -22,7 +22,7 @@ Many skills ask about session energy at the start:
 | **Quick progress** | Short sessions, need decisions, move forward | Clear scope upfront, primarily convergent methods, time-boxed, end with next actions |
 
 **Example prompt:**
-```
+```text
 Claude: Deep exploration today or quick progress?
 ```
 
@@ -124,7 +124,7 @@ How structured the output is:
 
 Most mode selection happens at session start:
 
-```
+```text
 Claude: A few questions before we begin:
         1. New project or continuing?
         2. Deep exploration or quick progress today?
@@ -135,7 +135,7 @@ Claude: A few questions before we begin:
 
 You can adjust modes during a session:
 
-```
+```text
 You: Let's switch to quick progress mode—I need to wrap up soon.
 
 Claude: Got it. Switching to quick progress. Let me summarize where we are
@@ -158,7 +158,7 @@ The same skill can produce very different outputs based on mode:
 
 ### Brainstorm: Deep Exploration
 
-```
+```text
 Session: 45 minutes
 Output: 3 pages of explored territory
 Methods: SCAMPER, Random Stimulus, First Principles
@@ -168,7 +168,7 @@ Next: "Sit with this before deciding"
 
 ### Brainstorm: Quick Progress
 
-```
+```text
 Session: 15 minutes
 Output: 1 page with clear decision
 Methods: Elimination Rounds

--- a/docs/concepts/pipelines.md
+++ b/docs/concepts/pipelines.md
@@ -1,0 +1,162 @@
+# Pipelines
+
+Pipelines are collections of skills designed to work together in sequence, with structured handoffs between stages.
+
+---
+
+## Why Pipelines?
+
+Complex creative work benefits from specialists, not generalists. Just as traditional publishing has developmental editors, copy editors, fact-checkers, and indexers, skill pipelines provide specialized expertise at each stage.
+
+Each skill in a pipeline:
+
+- Has a **specific job** (not a vague responsibility)
+- Receives **structured input** from upstream skills
+- Produces **structured output** for downstream skills
+- Knows its **scope boundaries** (what it does and doesn't do)
+
+---
+
+## Available Pipelines
+
+### Non-Fiction Book Factory
+
+A complete pipeline for developing nonfiction books from initial idea to chapter-level architecture.
+
+```mermaid
+flowchart LR
+    A[book-ideation] --> B[book-idea-validator]
+    B --> C[book-market-research]
+    C --> D[book-architect]
+    D --> E[book-research-assistant]
+    E --> F[chapter-architect]
+```
+
+| Skill | Job | Scope Boundary |
+|-------|-----|----------------|
+| book-ideation | Develop raw ideas into structured concepts | Concept only, not validation |
+| book-idea-validator | Test intellectual merit | Merit only, not market |
+| book-market-research | Assess commercial viability | Market only, not structure |
+| book-architect | Design reader journey and structure | Architecture only, not content |
+| book-research-assistant | Fill research gaps | Research only, not drafting |
+| chapter-architect | Plan chapters at beat level | Planning only, not drafting |
+
+### Ebook Factory
+
+A streamlined pipeline for creating ebooks—shorter, concentrated solutions.
+
+```mermaid
+flowchart LR
+    A[ebook-discovery] --> B[ebook-concept-development]
+```
+
+| Skill | Job |
+|-------|-----|
+| ebook-discovery | Surface ebook ideas from various sources |
+| ebook-concept-development | Develop ideas into structured concepts |
+
+### Writing Pipeline
+
+A pipeline for capturing and replicating authentic writing voices.
+
+```mermaid
+flowchart LR
+    A[writing-dna-discovery] --> B[ghost-writer]
+```
+
+| Skill | Job |
+|-------|-----|
+| writing-dna-discovery | Capture voice patterns through interview and analysis |
+| ghost-writer | Produce drafts at ~80% voice accuracy |
+
+---
+
+## Pipeline Principles
+
+### 1. Skills Hand Off to Each Other
+
+Each skill produces structured output that the next skill consumes. This creates a consistent, repeatable workflow.
+
+```
+Skill A → [Handoff Document] → Skill B → [Handoff Document] → Skill C
+```
+
+### 2. Validate Before Investing
+
+Pipelines include explicit validation gates to prevent wasted effort:
+
+- **book-idea-validator** — Is the idea intellectually sound?
+- **book-market-research** — Is there commercial potential?
+
+These gates produce Go/Revise/Kill recommendations before significant investment.
+
+### 3. Each Skill Knows Its Boundaries
+
+Skills are explicit about what they do and don't do:
+
+```markdown
+This skill validates **intellectual merit**, not:
+- Commercial viability (that's market-research)
+- Structural decisions (that's book-architect)
+- Writing quality (that's the editing pipeline)
+```
+
+This prevents scope creep and keeps each skill focused.
+
+### 4. Upstream Skills Can Receive Feedback
+
+Information flows both ways:
+
+- **Forward:** Handoff documents move work downstream
+- **Backward:** If a downstream skill discovers problems, feedback goes upstream
+
+Example: If book-research-assistant discovers the thesis is flawed, feedback goes to book-architect for structural revision.
+
+---
+
+## When to Use Pipelines
+
+**Use a pipeline when:**
+
+- Work is complex enough to benefit from specialized stages
+- You want consistent quality through structured processes
+- Multiple skills naturally chain together
+
+**Use standalone skills when:**
+
+- Work is self-contained (like general brainstorming)
+- You need just one capability
+- The task doesn't fit a multi-stage process
+
+---
+
+## Entering a Pipeline
+
+You don't have to start at the beginning:
+
+| Entry Point | What You Bring |
+|-------------|----------------|
+| Start of pipeline | Raw idea or nothing |
+| Middle of pipeline | Outputs from earlier stages |
+| Specific skill | Whatever that skill requires |
+
+For example, if you already have a Book Concept Document, you can skip book-ideation and start at book-idea-validator.
+
+---
+
+## Pipeline vs. Standalone
+
+| Aspect | Pipeline Skills | Standalone Skills |
+|--------|-----------------|-------------------|
+| Dependencies | Require upstream outputs | Self-contained |
+| Handoffs | Produce structured docs for downstream | Produce general outputs |
+| Scope | Narrow and specialized | Broader and flexible |
+| Example | book-architect | brainstorm |
+
+---
+
+## Related Concepts
+
+- [Handoffs](handoffs.md) — The structured documents that pass between skills
+- [Session Continuity](session-continuity.md) — How work persists within a skill
+- [Modes & Registers](modes-and-registers.md) — Adapting to different situations

--- a/docs/concepts/session-continuity.md
+++ b/docs/concepts/session-continuity.md
@@ -1,0 +1,176 @@
+# Session Continuity
+
+How skills maintain context across sessions spanning days or weeks.
+
+---
+
+## The Problem
+
+Creative and analytical work rarely completes in one sitting. You might brainstorm today, think overnight, and continue tomorrow. Traditional AI conversations lose context between sessions—you have to re-explain everything each time.
+
+Session continuity solves this through **versioned documents** that capture the full state of work.
+
+---
+
+## How It Works
+
+### Versioned Documents
+
+Each session produces a new version of the working document:
+
+```
+project-name/
+├── _index.md           # Version history, decision log
+├── project-name-v1.md  # Session 1 output
+├── project-name-v2.md  # Session 2 output
+├── project-name-v3.md  # Session 3 output
+└── ...
+```
+
+When you return, you provide the latest version file. Claude reads it and picks up exactly where you left off.
+
+### What Gets Captured
+
+Version documents typically include:
+
+| Section | Purpose |
+|---------|---------|
+| **Quick Context** | 2-3 sentences on current state |
+| **Session Log** | Date, duration, energy level, methods used |
+| **Current Thinking** | The substance of where things stand |
+| **Ideas/Elements** | Organized by maturity or development status |
+| **Decisions Made** | With reasoning, not just conclusions |
+| **Open Questions** | Unresolved items needing thought |
+| **Next Steps** | Clear actionable items |
+
+### The Index File
+
+A separate index file tracks the project across all versions:
+
+```markdown
+# Project Index
+
+## Version History
+- v1 (Jan 15): Initial brainstorm, identified 3 directions
+- v2 (Jan 18): Deep dive on direction A, parked B and C
+- v3 (Jan 22): Refined direction A, ready for validation
+
+## Major Decisions
+1. Target reader is mid-career professionals (v2)
+2. Focus on transformation, not information (v3)
+```
+
+---
+
+## Session Patterns
+
+### Starting a New Session
+
+```
+You: Let's continue the productivity app brainstorm.
+
+Claude: I'll need the latest version file to pick up where we left off.
+        Can you share project-name-v3.md?
+
+You: [uploads file]
+
+Claude: Got it. Reading through v3...
+
+        Last session (Jan 22), we refined the target reader to
+        mid-career professionals and identified three key pain points.
+        The overnight question was "Would you pay for this yourself?"
+
+        How did that land? Ready to pick up there?
+```
+
+### During a Session
+
+Claude tracks the conversation and captures significant developments:
+
+- When decisions crystallize
+- When thinking shifts meaningfully
+- When new questions emerge
+- At natural breakpoints
+
+### Ending a Session
+
+Every session concludes with:
+
+1. **Exit Summary** — Current state, key decisions, open questions, next steps
+2. **The Overnight Test** — A question to sit with before next session
+3. **Version Creation** — New versioned document capturing everything
+
+---
+
+## Session Energy
+
+Many skills ask about "session energy" at the start:
+
+| Mode | Best For | Behavior |
+|------|----------|----------|
+| **Deep exploration** | Long sessions, open-ended thinking | More questions, more methods, embrace tangents |
+| **Quick progress** | Short sessions, need decisions | Clear scope, primarily convergent, time-boxed |
+
+This lets the skill adapt to your available time and mental state.
+
+---
+
+## Multi-Week Projects
+
+For projects spanning weeks:
+
+### Synthesis Documents
+
+After 3+ sessions, skills may offer:
+
+> "We've had 5 sessions on this. Want me to create a synthesis document that distills our current best thinking?"
+
+Synthesis documents consolidate learning without losing the version history.
+
+### Returning After a Break
+
+If significant time has passed, Claude won't assume you remember the context:
+
+```
+Claude: Welcome back! It's been 12 days since our last session.
+        Reading through v4, here's where things stand...
+        [provides comprehensive status summary]
+
+        Does this still feel current, or has your thinking shifted?
+```
+
+---
+
+## Best Practices
+
+### Do
+
+- **Keep version files** — The history matters; don't delete old versions
+- **Provide the latest version** — Always share the most recent file when continuing
+- **Use the overnight test** — Percolation between sessions often yields breakthroughs
+- **Let Claude summarize** — The status recap catches you up and verifies shared understanding
+
+### Don't
+
+- **Overwrite files** — Create new versions, don't modify old ones
+- **Skip the exit summary** — This captures crucial context for next session
+- **Rush session endings** — Proper closure enables proper continuation
+
+---
+
+## Technical Implementation
+
+Skills implement continuity through:
+
+1. **Document Templates** — Consistent structure for version files
+2. **Session Flow** — Start/during/end patterns in SKILL.md
+3. **Status Checks** — Questions at session start to orient
+4. **Update Triggers** — When to capture changes in the document
+
+---
+
+## Related Concepts
+
+- [Pipelines](pipelines.md) — How skills chain together
+- [Handoffs](handoffs.md) — Documents that pass between skills
+- [Modes & Registers](modes-and-registers.md) — Adapting to different situations

--- a/docs/developer-guide/building-and-packaging.md
+++ b/docs/developer-guide/building-and-packaging.md
@@ -1,0 +1,278 @@
+# Building & Packaging
+
+How to package skills for Claude.ai upload.
+
+---
+
+## Overview
+
+The `build.py` script packages skills into `.skill` files (ZIP archives) that can be uploaded to Claude.ai.
+
+---
+
+## Prerequisites
+
+```bash
+pip install pyyaml
+```
+
+---
+
+## Basic Usage
+
+### Package a Single Skill
+
+```bash
+python build.py <skill-name>
+```
+
+Example:
+```bash
+python build.py brainstorm
+# Output: dist/brainstorm.skill
+```
+
+### Package All Skills
+
+```bash
+python build.py --all
+```
+
+### List Available Skills
+
+```bash
+python build.py --list
+```
+
+---
+
+## What Gets Packaged
+
+The build script creates a ZIP archive containing:
+
+| Included | Excluded |
+|----------|----------|
+| SKILL.md | Hidden files (.*) |
+| references/ | .DS_Store |
+| assets/ | __pycache__ |
+| | README.md (skill-level) |
+
+---
+
+## Validation
+
+The build script validates each skill before packaging:
+
+### Required: YAML Frontmatter
+
+```yaml
+---
+name: skill-name
+description: Description of at least 20 characters.
+---
+```
+
+### Validation Checks
+
+| Check | Requirement |
+|-------|-------------|
+| SKILL.md exists | File must be present |
+| Frontmatter present | Must start with `---` |
+| name field | Required |
+| description field | Required, min 20 chars |
+
+### Common Errors
+
+**Missing SKILL.md:**
+```
+Error: brainstorm/SKILL.md not found
+```
+→ Ensure SKILL.md exists in the skill folder
+
+**Missing frontmatter:**
+```
+Error: SKILL.md must start with YAML frontmatter (---)
+```
+→ Add `---` at top and bottom of frontmatter block
+
+**Missing required field:**
+```
+Error: Missing required field: name
+```
+→ Add name field to frontmatter
+
+**Description too short:**
+```
+Error: Description must be at least 20 characters
+```
+→ Write a more comprehensive description
+
+---
+
+## Workflow
+
+### Creating a New Skill
+
+1. **Create folder structure**
+   ```
+   my-skill/
+   ├── SKILL.md
+   ├── references/     # optional
+   └── assets/         # optional
+   ```
+
+2. **Write SKILL.md** with proper frontmatter
+
+3. **Add references and assets** as needed
+
+4. **Validate**
+   ```bash
+   python build.py --list
+   # Check for ✓ valid next to your skill
+   ```
+
+5. **Package**
+   ```bash
+   python build.py my-skill
+   ```
+
+6. **Upload** to Claude.ai → Settings → Skills
+
+### Updating a Skill
+
+1. Make changes to skill files
+
+2. Re-package
+   ```bash
+   python build.py my-skill
+   ```
+
+3. Upload new `.skill` file to Claude.ai (replaces existing)
+
+---
+
+## Skill Naming
+
+The build command uses the skill folder name:
+
+| Folder Location | Build Command |
+|-----------------|---------------|
+| `brainstorm/` | `python build.py brainstorm` |
+| `non-fiction-book-factory/book-ideation/` | `python build.py book-ideation` |
+| `writing/ghost-writer/` | `python build.py ghost-writer` |
+
+Note: Use the skill name, not the full path.
+
+---
+
+## Output Location
+
+All packages go to the `dist/` directory:
+
+```
+dist/
+├── brainstorm.skill
+├── book-ideation.skill
+├── book-idea-validator.skill
+└── ...
+```
+
+---
+
+## Testing Before Upload
+
+### Local Validation
+
+```bash
+python build.py --list
+```
+
+Check that your skill shows ✓ valid.
+
+### Build and Inspect
+
+```bash
+python build.py my-skill
+
+# Inspect the package (it's a ZIP file)
+unzip -l dist/my-skill.skill
+```
+
+### Test with Claude Code
+
+Before packaging for Claude.ai, test with Claude Code:
+
+```markdown
+# CLAUDE.md
+
+When testing my-skill, read and follow /path/to/my-skill/SKILL.md.
+```
+
+Run through various scenarios to validate behavior.
+
+---
+
+## Troubleshooting
+
+### "Skill not found"
+
+```
+Error: Skill 'my-skil' not found
+```
+
+- Check spelling
+- Run `python build.py --list` to see valid names
+- Ensure SKILL.md exists in the folder
+
+### "Permission denied"
+
+```bash
+mkdir -p dist
+chmod 755 dist
+```
+
+### "Invalid YAML"
+
+- Check frontmatter syntax
+- Ensure `---` on its own lines
+- Validate YAML formatting
+
+### Package too large
+
+Claude.ai may have size limits. If your skill is very large:
+
+- Move large content to references (lazy-loaded)
+- Compress images
+- Remove unnecessary assets
+
+---
+
+## Best Practices
+
+### Before Building
+
+- [ ] SKILL.md has proper frontmatter
+- [ ] Description is comprehensive (>20 chars)
+- [ ] References are properly pointed to
+- [ ] Assets are organized
+- [ ] No unnecessary files
+
+### After Building
+
+- [ ] Package appears in dist/
+- [ ] Package size is reasonable
+- [ ] Contents look correct (unzip to inspect)
+
+### After Uploading
+
+- [ ] Skill appears in Claude.ai Settings
+- [ ] Test activation with relevant prompts
+- [ ] Verify behavior matches expectations
+
+---
+
+## Related
+
+- [Skill Anatomy](skill-anatomy.md) — Understand structure
+- [Writing SKILL.md](writing-skill-md.md) — Best practices
+- [Build Commands Reference](../reference/build-commands.md) — Full CLI reference

--- a/docs/developer-guide/contributing.md
+++ b/docs/developer-guide/contributing.md
@@ -1,0 +1,220 @@
+# Contributing
+
+Guidelines for contributing to the Claude Skills repository.
+
+---
+
+## Ways to Contribute
+
+### Report Issues
+
+Found a bug or have a suggestion?
+
+1. Check existing issues first
+2. Open a new issue with:
+   - Clear description
+   - Steps to reproduce (if bug)
+   - Expected vs. actual behavior
+   - Skill name and version
+
+### Improve Existing Skills
+
+- Fix bugs or issues
+- Improve clarity of instructions
+- Add missing reference documentation
+- Enhance templates
+
+### Create New Skills
+
+- Propose new skills via issue first
+- Follow the skill structure guidelines
+- Include comprehensive testing
+
+---
+
+## Development Setup
+
+### Clone the Repository
+
+```bash
+git clone https://github.com/robertguss/claude-skills.git
+cd claude-skills
+```
+
+### Install Dependencies
+
+```bash
+pip install pyyaml
+```
+
+### Verify Setup
+
+```bash
+python build.py --list
+```
+
+---
+
+## Skill Development Guidelines
+
+### Structure
+
+Follow the standard skill structure:
+
+```
+my-skill/
+├── SKILL.md              # Required
+├── references/           # Optional
+│   └── *.md
+└── assets/               # Optional
+    └── templates/
+        └── *.md
+```
+
+### SKILL.md Requirements
+
+1. **Frontmatter** with name and description (min 20 chars)
+2. **Clear workflow** with defined inputs/outputs
+3. **Reference pointers** if using bundled resources
+4. **Concise content** — challenge every paragraph
+
+### Quality Standards
+
+| Aspect | Requirement |
+|--------|-------------|
+| **Focused** | One job, done well |
+| **Concise** | Only essential information |
+| **Structured** | Clear workflow with inputs/outputs |
+| **Progressive** | Core in SKILL.md, details in references |
+| **Tested** | Validated with real usage |
+
+---
+
+## Pull Request Process
+
+### 1. Create a Branch
+
+```bash
+git checkout -b feature/my-improvement
+```
+
+### 2. Make Changes
+
+- Follow existing patterns
+- Update relevant documentation
+- Test thoroughly
+
+### 3. Validate
+
+```bash
+python build.py --list
+# Ensure your changes show ✓ valid
+
+python build.py <skill-name>
+# Ensure packaging succeeds
+```
+
+### 4. Commit
+
+Write clear commit messages:
+
+```
+Add voice calibration reference to ghost-writer
+
+- Added references/voice-calibration.md with techniques
+- Updated SKILL.md to point to new reference
+- Tested with sample voice DNA documents
+```
+
+### 5. Open Pull Request
+
+Include:
+- What changed and why
+- Testing performed
+- Any breaking changes
+
+---
+
+## Documentation Guidelines
+
+### When Documenting Skills
+
+- Focus on **how to use**, not how it works internally
+- Include **realistic examples**
+- Explain **when to use** each feature
+- Document **inputs and outputs** clearly
+
+### Style
+
+- Use active voice
+- Be concise
+- Prefer examples over explanations
+- Use tables for structured information
+
+---
+
+## Testing
+
+### Test with Claude Code
+
+Before submitting, test your changes:
+
+```markdown
+# CLAUDE.md
+
+When testing, read and follow /path/to/modified/SKILL.md.
+```
+
+### Test Scenarios
+
+- Happy path (normal usage)
+- Edge cases
+- Error conditions
+- Multi-session continuity (if applicable)
+
+### Test Packaging
+
+```bash
+python build.py <skill-name>
+unzip -l dist/<skill-name>.skill
+```
+
+Verify the package contains expected files.
+
+---
+
+## Code of Conduct
+
+### Be Respectful
+
+- Constructive feedback only
+- Assume good intent
+- Welcome newcomers
+
+### Quality Focus
+
+- Prioritize user experience
+- Maintain existing standards
+- Document thoroughly
+
+---
+
+## Getting Help
+
+- **Issues**: For bugs and feature requests
+- **Discussions**: For questions and ideas
+- **Documentation**: Start with the [Developer Guide](index.md)
+
+---
+
+## License
+
+Contributions are subject to the repository's license terms. See LICENSE for details.
+
+---
+
+## Related
+
+- [Skill Anatomy](skill-anatomy.md) — Understand skill structure
+- [Writing SKILL.md](writing-skill-md.md) — Best practices for instructions
+- [Building & Packaging](building-and-packaging.md) — Package skills for distribution

--- a/docs/developer-guide/index.md
+++ b/docs/developer-guide/index.md
@@ -1,0 +1,149 @@
+# Developer Guide
+
+Learn how to create, structure, and package your own Claude skills.
+
+---
+
+## Getting Started
+
+<div class="grid cards" markdown>
+
+-   :material-puzzle:{ .lg .middle } **[Skill Anatomy](skill-anatomy.md)**
+
+    ---
+
+    Understand the structure of a skill: SKILL.md, references, assets, and how they work together.
+
+-   :material-file-document:{ .lg .middle } **[Writing SKILL.md](writing-skill-md.md)**
+
+    ---
+
+    Best practices for writing effective skill instructions.
+
+-   :material-folder-multiple:{ .lg .middle } **[References & Assets](references-and-assets.md)**
+
+    ---
+
+    How to use bundled resources for progressive disclosure.
+
+-   :material-package-variant:{ .lg .middle } **[Building & Packaging](building-and-packaging.md)**
+
+    ---
+
+    Package skills for Claude.ai upload.
+
+-   :material-source-branch:{ .lg .middle } **[Contributing](contributing.md)**
+
+    ---
+
+    Guidelines for contributing to the skills repository.
+
+</div>
+
+---
+
+## Core Principles
+
+### Concise is Key
+
+The context window is a public good. Skills share it with everything else Claude needs: system prompt, conversation history, and user requests.
+
+**Default assumption: Claude is already very smart.** Only add context Claude doesn't already have. Challenge each piece of information:
+
+- "Does Claude really need this explanation?"
+- "Does this paragraph justify its token cost?"
+
+Prefer concise examples over verbose explanations.
+
+### Set Appropriate Degrees of Freedom
+
+Match specificity to the task's fragility and variability:
+
+| Freedom Level | When to Use | Example |
+|---------------|-------------|---------|
+| **High** | Multiple approaches valid, context-dependent | Text-based heuristics |
+| **Medium** | Preferred pattern exists, some variation OK | Pseudocode with parameters |
+| **Low** | Fragile operations, consistency critical | Specific scripts |
+
+Think of Claude as exploring a path: a narrow bridge needs specific guardrails (low freedom), while an open field allows many routes (high freedom).
+
+### Progressive Disclosure
+
+Skills use a three-level loading system:
+
+1. **Metadata** (name + description) — Always in context (~100 words)
+2. **SKILL.md body** — When skill triggers (<5k words ideal)
+3. **Bundled resources** — As needed by Claude (unlimited)
+
+This keeps context lean while making depth available on demand.
+
+---
+
+## Quick Start: Creating a Skill
+
+### 1. Create the folder structure
+
+```
+my-skill/
+├── SKILL.md              # Required
+├── references/           # Optional
+│   └── detailed-guide.md
+└── assets/               # Optional
+    └── template.md
+```
+
+### 2. Write the SKILL.md frontmatter
+
+```yaml
+---
+name: my-skill
+description: A clear description of what this skill does and when to use it. Should be at least 20 characters.
+---
+```
+
+### 3. Write the instructions
+
+```markdown
+# My Skill
+
+[Core instructions for Claude]
+
+## Workflow
+
+[Step-by-step guidance]
+
+## References
+
+For detailed information on X, see `references/detailed-guide.md`.
+```
+
+### 4. Package for Claude.ai
+
+```bash
+python build.py my-skill
+```
+
+### 5. Upload
+
+Go to Claude.ai → Settings → Skills → Upload `dist/my-skill.skill`
+
+---
+
+## What Makes a Good Skill?
+
+| Quality | Description |
+|---------|-------------|
+| **Focused** | One job, done well |
+| **Concise** | Only essential information |
+| **Structured** | Clear workflow with defined inputs/outputs |
+| **Progressive** | Core in SKILL.md, details in references |
+| **Tested** | Validated with real usage |
+
+---
+
+## Next Steps
+
+1. [:octicons-arrow-right-24: Skill Anatomy](skill-anatomy.md) — Start here to understand structure
+2. [:octicons-arrow-right-24: Writing SKILL.md](writing-skill-md.md) — Best practices for instructions
+3. [:octicons-arrow-right-24: References & Assets](references-and-assets.md) — Bundling resources
+4. [:octicons-arrow-right-24: Building & Packaging](building-and-packaging.md) — Create .skill files

--- a/docs/developer-guide/references-and-assets.md
+++ b/docs/developer-guide/references-and-assets.md
@@ -1,0 +1,322 @@
+# References & Assets
+
+How to use bundled resources for progressive disclosure.
+
+---
+
+## Overview
+
+Skills can bundle additional resources beyond SKILL.md:
+
+| Folder | Purpose | When Loaded |
+|--------|---------|-------------|
+| `references/` | Documentation for Claude to read | On-demand, when needed |
+| `assets/` | Files for Claude's output | Used, not loaded into context |
+
+This enables progressive disclosure: core instructions in SKILL.md, depth available when needed.
+
+---
+
+## References
+
+Documentation Claude loads into context as needed.
+
+### When to Use References
+
+- **Detailed method catalogs** — Full explanations too long for SKILL.md
+- **Domain knowledge** — Schemas, specifications, policies
+- **Examples and patterns** — Extensive examples for specific scenarios
+- **Workflow variants** — Different approaches for different situations
+
+### Directory Structure
+
+```
+references/
+├── methods-detailed.md      # Full method explanations
+├── methods-quick.md         # Quick reference table
+├── common-problems.md       # Antipatterns to avoid
+└── best-practices.md        # Recommendations
+```
+
+### Pointing to References
+
+In SKILL.md, tell Claude when to load each reference:
+
+```markdown
+## Methods
+
+For quick method selection, see `references/methods-quick.md`.
+
+For full method explanations (to share with user), see `references/methods-detailed.md`.
+```
+
+```markdown
+## Troubleshooting
+
+When encountering structural problems, load `references/common-problems.md`.
+```
+
+### Conditional Loading
+
+References are powerful when loaded conditionally:
+
+```markdown
+## Framework Selection
+
+Based on book type:
+- Argument-driven → Load `references/argument-frameworks.md`
+- Narrative → Load `references/narrative-frameworks.md`
+- How-to → Load `references/how-to-frameworks.md`
+```
+
+Claude only loads what's relevant to the current task.
+
+### Structuring Long References
+
+For files >100 lines, include a table of contents:
+
+```markdown
+# Methods Detailed Reference
+
+## Table of Contents
+
+1. [Divergent Methods](#divergent-methods)
+2. [Convergent Methods](#convergent-methods)
+3. [Problem-Framing Methods](#problem-framing-methods)
+4. [Evaluation Methods](#evaluation-methods)
+
+---
+
+## Divergent Methods
+
+### SCAMPER
+[content]
+
+### Random Stimulus
+[content]
+```
+
+This lets Claude see the full scope when previewing.
+
+---
+
+## Assets
+
+Files used in Claude's output, not loaded into context.
+
+### When to Use Assets
+
+- **Templates** — Document structures to fill in
+- **Boilerplate** — Starter code or project structures
+- **Visual assets** — Images, icons, fonts
+- **Sample files** — Examples to copy or modify
+
+### Directory Structure
+
+```
+assets/
+├── templates/
+│   ├── project-template.md
+│   ├── index-template.md
+│   └── report-template.md
+├── boilerplate/
+│   └── starter-project/
+└── images/
+    └── logo.png
+```
+
+### Using Templates
+
+Reference templates in SKILL.md:
+
+```markdown
+## Outputs
+
+Use `assets/templates/project-template.md` for new project documents.
+
+Use `assets/templates/index-template.md` for project index files.
+```
+
+Claude uses the template structure without loading the entire file into context.
+
+### Template Design
+
+Good templates include:
+
+```markdown
+# [Project Name] - v[N]
+
+## Quick Context
+[2-3 sentences: what is this, current state]
+
+## Session Log
+- Date: [DATE]
+- Duration: [TIME]
+- Energy: [Deep/Quick]
+- Mode: [Connected/Clean-slate]
+- Methods used: [LIST]
+
+## Current Thinking
+[The substance of where things stand]
+
+## Ideas Inventory
+
+### Raw
+[Unexamined ideas]
+
+### Developing
+[Being explored]
+
+### Refined
+[Ready for evaluation]
+
+## Decisions Made
+[With reasoning]
+
+## Open Questions
+[Unresolved items]
+
+## Next Steps
+[Clear actionable items]
+```
+
+---
+
+## Progressive Disclosure Patterns
+
+### Pattern 1: High-Level Guide with References
+
+SKILL.md contains core workflow; references contain depth:
+
+```markdown
+# Document Processing
+
+## Quick Start
+
+Extract text with pdfplumber:
+[brief example]
+
+## Advanced Features
+
+- **Form filling**: See `references/forms.md`
+- **OCR processing**: See `references/ocr.md`
+- **Batch operations**: See `references/batch.md`
+```
+
+### Pattern 2: Domain-Specific Organization
+
+For multi-domain skills:
+
+```
+analytics-skill/
+├── SKILL.md (overview and navigation)
+└── references/
+    ├── sales-metrics.md
+    ├── marketing-metrics.md
+    ├── product-metrics.md
+    └── finance-metrics.md
+```
+
+When user asks about sales, Claude only loads `sales-metrics.md`.
+
+### Pattern 3: Framework Variants
+
+For skills supporting multiple frameworks:
+
+```
+deployment-skill/
+├── SKILL.md (workflow + selection guidance)
+└── references/
+    ├── aws-patterns.md
+    ├── gcp-patterns.md
+    └── azure-patterns.md
+```
+
+### Pattern 4: Conditional Details
+
+Show basic in SKILL.md, link to advanced:
+
+```markdown
+## Document Editing
+
+For simple edits, modify XML directly.
+
+**For tracked changes**: See `references/redlining.md`
+**For complex formatting**: See `references/ooxml.md`
+```
+
+---
+
+## Best Practices
+
+### References
+
+| Do | Don't |
+|----|-------|
+| Clear pointers from SKILL.md | Assume Claude knows references exist |
+| One level deep from SKILL.md | Deeply nested references |
+| Table of contents for long files | Unstructured walls of text |
+| Conditional loading | Load everything always |
+
+### Assets
+
+| Do | Don't |
+|----|-------|
+| Clear template structures | Overly complex templates |
+| Organized subfolders | Flat directory with many files |
+| Only what's needed | Every possible template |
+
+### General
+
+| Do | Don't |
+|----|-------|
+| Single source of truth | Duplicate across SKILL.md and references |
+| Describe when to load | Leave loading implicit |
+| Keep SKILL.md lean | Put everything in SKILL.md |
+
+---
+
+## Example: Complete Structure
+
+A skill with well-organized resources:
+
+```
+book-architect/
+├── SKILL.md
+├── references/
+│   ├── structural-frameworks.md    # Framework options
+│   ├── chapter-architecture.md     # Chapter design
+│   ├── pacing-cognitive-load.md    # Pacing guidance
+│   ├── reader-resistance.md        # Objection handling
+│   ├── proof-burden-mapping.md     # Evidence requirements
+│   └── common-problems.md          # Antipatterns
+└── assets/
+    └── templates/
+        ├── master-architecture-template.md
+        ├── section-blueprint-template.md
+        ├── research-gaps-template.md
+        ├── progress-tracker-template.md
+        └── decision-log-template.md
+```
+
+SKILL.md points to references:
+```markdown
+## References
+
+Load as needed:
+- `references/structural-frameworks.md` — When selecting framework
+- `references/chapter-architecture.md` — When designing chapters
+- `references/common-problems.md` — When troubleshooting
+
+## Templates
+
+Use templates from `assets/templates/` for outputs.
+```
+
+---
+
+## Related
+
+- [Skill Anatomy](skill-anatomy.md) — Overall structure
+- [Writing SKILL.md](writing-skill-md.md) — Instructions best practices
+- [Building & Packaging](building-and-packaging.md) — Create .skill files

--- a/docs/developer-guide/skill-anatomy.md
+++ b/docs/developer-guide/skill-anatomy.md
@@ -1,0 +1,263 @@
+# Skill Anatomy
+
+Understanding the structure of a skill.
+
+---
+
+## Overview
+
+Skills are modular, self-contained packages that extend Claude's capabilities. They consist of a required SKILL.md file and optional bundled resources.
+
+```
+skill-name/
+├── SKILL.md              # Required - core instructions
+├── references/           # Optional - documentation loaded on-demand
+└── assets/               # Optional - templates and files for output
+```
+
+---
+
+## SKILL.md (Required)
+
+Every skill must have a SKILL.md file containing:
+
+### YAML Frontmatter
+
+```yaml
+---
+name: my-skill
+description: A clear description of what this skill does and when Claude should use it. Must be at least 20 characters.
+---
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Skill identifier (should match folder name) |
+| `description` | Yes | When to activate (min 20 chars) |
+
+The description is critical—it's what Claude reads to determine when to activate the skill. Be clear and comprehensive.
+
+### Markdown Body
+
+The body contains instructions for Claude:
+
+```markdown
+# Skill Name
+
+[Brief overview]
+
+## Core Philosophy
+
+[Guiding principles]
+
+## Workflow
+
+[Step-by-step process]
+
+## Inputs
+
+[What the skill needs]
+
+## Outputs
+
+[What the skill produces]
+
+## References
+
+[Pointers to bundled resources]
+```
+
+---
+
+## References (Optional)
+
+Documentation intended to be loaded into context as needed.
+
+```
+references/
+├── detailed-guide.md
+├── patterns.md
+└── examples.md
+```
+
+### When to Use References
+
+- Documentation Claude should reference while working
+- Database schemas, API specifications
+- Domain knowledge, company policies
+- Detailed workflow guides
+- Anything too long for SKILL.md but needed during execution
+
+### Best Practices
+
+- **Keep SKILL.md lean** — Move details to references
+- **Clear pointers** — Tell Claude when to load each reference
+- **Structure long files** — Include table of contents for files >100 lines
+- **Avoid duplication** — Information lives in one place, not both
+
+### Example Reference Pattern
+
+In SKILL.md:
+```markdown
+## Methods
+
+For detailed method explanations, see `references/methods-detailed.md`.
+
+For quick method selection, see `references/methods-quick.md`.
+```
+
+Claude loads only what's needed for the current task.
+
+---
+
+## Assets (Optional)
+
+Files not intended for context, but used in Claude's output.
+
+```
+assets/
+├── templates/
+│   └── project-template.md
+├── icons/
+│   └── logo.png
+└── boilerplate/
+    └── starter-code/
+```
+
+### When to Use Assets
+
+- Templates that get filled in or modified
+- Images and icons for output
+- Boilerplate code to copy
+- Sample documents
+- Fonts, styles, or other resources
+
+### Best Practices
+
+- **Separate from references** — Assets are for output, references are for context
+- **Clear organization** — Use subfolders for different asset types
+- **Minimal footprint** — Only include what's actually needed
+
+---
+
+## What NOT to Include
+
+Skills should only contain essential files. Do NOT create:
+
+- README.md (for the skill itself)
+- INSTALLATION_GUIDE.md
+- QUICK_REFERENCE.md
+- CHANGELOG.md
+- User-facing documentation
+
+The skill is for Claude, not human readers. It should contain only what Claude needs to do the job.
+
+---
+
+## Progressive Disclosure
+
+Skills use three levels of loading:
+
+| Level | Content | When Loaded | Size |
+|-------|---------|-------------|------|
+| 1 | name + description | Always | ~100 words |
+| 2 | SKILL.md body | When triggered | <5k words |
+| 3 | References | As needed | Unlimited |
+
+This keeps context lean while making depth available on demand.
+
+### Level 1: Metadata
+
+Always in context. Claude reads this to decide whether to activate the skill.
+
+```yaml
+---
+name: brainstorm
+description: Collaborative brainstorming partner for multi-session ideation projects. Use when the user wants to brainstorm, ideate, explore ideas...
+---
+```
+
+### Level 2: SKILL.md Body
+
+Loaded only when skill triggers. Should contain:
+
+- Core workflow
+- Key decisions
+- Navigation to references
+- Essential behaviors
+
+Target: <500 lines, <5k words
+
+### Level 3: References
+
+Loaded only when Claude determines they're needed. Can contain:
+
+- Detailed method catalogs
+- Extensive examples
+- Domain-specific knowledge
+- Any depth required
+
+---
+
+## Skill Patterns
+
+### Simple Skill
+
+Single-purpose, no references needed:
+
+```
+simple-skill/
+└── SKILL.md
+```
+
+### Skill with References
+
+Core instructions plus depth:
+
+```
+research-skill/
+├── SKILL.md
+└── references/
+    ├── source-evaluation.md
+    └── citation-standards.md
+```
+
+### Skill with Templates
+
+Produces structured output:
+
+```
+report-skill/
+├── SKILL.md
+├── references/
+│   └── formatting-guide.md
+└── assets/
+    └── templates/
+        └── report-template.md
+```
+
+### Complex Pipeline Skill
+
+Full-featured skill with everything:
+
+```
+book-architect/
+├── SKILL.md
+├── references/
+│   ├── structural-frameworks.md
+│   ├── chapter-architecture.md
+│   ├── pacing-cognitive-load.md
+│   └── common-problems.md
+└── assets/
+    └── templates/
+        ├── master-architecture-template.md
+        └── section-blueprint-template.md
+```
+
+---
+
+## Related
+
+- [Writing SKILL.md](writing-skill-md.md) — Best practices for instructions
+- [References & Assets](references-and-assets.md) — Bundling resources
+- [Building & Packaging](building-and-packaging.md) — Create .skill files

--- a/docs/developer-guide/writing-skill-md.md
+++ b/docs/developer-guide/writing-skill-md.md
@@ -1,0 +1,365 @@
+# Writing SKILL.md
+
+Best practices for writing effective skill instructions.
+
+---
+
+## The Two Parts
+
+Every SKILL.md has two parts:
+
+### 1. Frontmatter (Critical)
+
+```yaml
+---
+name: skill-name
+description: A comprehensive description of what this skill does and when Claude should use it. This is what Claude reads to decide whether to activate the skill.
+---
+```
+
+The description is the most important part—it determines when the skill activates.
+
+**Good description:**
+```yaml
+description: Collaborative brainstorming partner for multi-session ideation projects. Use when the user wants to brainstorm, ideate, explore ideas, or think through problems—whether for SaaS products, software tools, book ideas, newsletter content, business strategies, or any creative/analytical challenge.
+```
+
+**Weak description:**
+```yaml
+description: A brainstorming skill.
+```
+
+### 2. Body (Instructions)
+
+The markdown content Claude loads when the skill triggers.
+
+---
+
+## Body Structure
+
+A well-structured SKILL.md typically includes:
+
+### Core Philosophy
+
+What principles guide this skill:
+
+```markdown
+## Core Philosophy
+
+1. **Reader-first architecture.** Every decision serves the reader's experience.
+
+2. **Chapters are journeys, not containers.** Each transforms the reader.
+
+3. **Expert with warmth.** Direct about problems, supportive of the person.
+```
+
+### Session Flow
+
+How work progresses:
+
+```markdown
+## Session Flow
+
+### Session Start
+[What happens when starting]
+
+### During Session
+[Key activities and behaviors]
+
+### Session End
+[How sessions conclude, outputs produced]
+```
+
+### Inputs & Outputs
+
+What the skill needs and produces:
+
+```markdown
+## Inputs
+
+| Input | Required | Description |
+|-------|----------|-------------|
+| Topic | Yes | What to work on |
+| Prior version | If continuing | Previous session output |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| Version document | Captures session work |
+| Decision log | Records choices with reasoning |
+```
+
+### Reference Pointers
+
+Navigation to bundled resources:
+
+```markdown
+## References
+
+Load as needed:
+
+- `references/methods-detailed.md` — Full method explanations
+- `references/common-problems.md` — Antipatterns to avoid
+```
+
+---
+
+## Writing Principles
+
+### Concise is Key
+
+Challenge every sentence:
+
+- "Does Claude really need this?"
+- "Does this paragraph justify its token cost?"
+- "Could an example replace this explanation?"
+
+**Before (verbose):**
+```markdown
+When working with users on brainstorming tasks, it is very important to
+remember that Claude should be acting as a collaborative partner rather
+than simply a tool that generates ideas on demand. This means that Claude
+should proactively offer observations, challenge weak reasoning, and
+surface connections to other work the user has done.
+```
+
+**After (concise):**
+```markdown
+Claude is a collaborative partner, not an idea generator:
+- Offer observations proactively
+- Challenge weak reasoning
+- Surface connections to other work
+```
+
+### Set Appropriate Freedom
+
+Match specificity to fragility:
+
+**High freedom (flexible):**
+```markdown
+## Collaboration Style
+
+- Be direct about problems
+- Push back on weak ideas
+- Ask hard questions
+```
+
+**Low freedom (prescriptive):**
+```markdown
+## File Naming
+
+ALWAYS use this format:
+- `project-name-v1.md`
+- `project-name-v2.md`
+- Never overwrite, always increment version
+```
+
+### Use Examples
+
+Prefer examples over explanations:
+
+**Instead of explaining:**
+```markdown
+Claude should mark decision points explicitly when significant
+choices are made during the session.
+```
+
+**Show an example:**
+```markdown
+Mark decision points explicitly:
+
+"This feels like a decision point. Should we log:
+'Target reader is mid-career professionals'?"
+```
+
+---
+
+## Behavior Specifications
+
+### Collaboration Behaviors
+
+Describe how Claude should engage:
+
+```markdown
+**Collaboration behaviors:**
+
+- Proactively offer observations: "I notice you keep circling back to X—want to dig into why?"
+- Challenge weak reasoning: "I'm not convinced by that reasoning. Here's why..."
+- Ask the hard questions the user might avoid
+```
+
+### Decision Points
+
+How to handle significant moments:
+
+```markdown
+**Decision checkpoints:**
+
+When a decision crystallizes:
+- "This feels like a decision point. Should we log: [decision statement]?"
+- Capture the reasoning, not just the conclusion
+```
+
+### Boundaries
+
+What the skill does and doesn't do:
+
+```markdown
+## Scope Boundaries
+
+This skill validates **intellectual merit**, not:
+- Commercial viability (that's market-research)
+- Structural decisions (that's book-architect)
+- Writing quality (that's the editing pipeline)
+```
+
+---
+
+## Workflow Patterns
+
+### Linear Workflow
+
+For sequential processes:
+
+```markdown
+## Workflow
+
+### Phase 1: Setup
+[First phase activities]
+
+### Phase 2: Development
+[Second phase activities]
+
+### Phase 3: Completion
+[Final phase activities]
+```
+
+### Conditional Workflow
+
+For branching logic:
+
+```markdown
+## Session Start
+
+**If new project:**
+1. Ask context questions
+2. Initialize documents
+3. Begin development
+
+**If continuing:**
+1. Request version file
+2. Summarize current state
+3. Confirm direction
+```
+
+### Iterative Workflow
+
+For cycles:
+
+```markdown
+## Validation Loop
+
+For each gap:
+1. Confirm gap to validate
+2. Request research outputs
+3. Review against criteria
+4. Render verdict
+5. Update tracker
+6. Proceed to next gap
+```
+
+---
+
+## Common Mistakes
+
+### Too Long
+
+SKILL.md should be <500 lines. Move details to references.
+
+**Problem:** 1500-line SKILL.md with everything included
+
+**Solution:** Core workflow in SKILL.md, details in `references/`
+
+### Missing Reference Pointers
+
+Claude can't load what it doesn't know exists.
+
+**Problem:** References exist but aren't mentioned
+
+**Solution:**
+```markdown
+## References
+
+For detailed framework options, see `references/frameworks.md`.
+```
+
+### Vague Descriptions
+
+The frontmatter description determines activation.
+
+**Problem:** "A skill for writing things."
+
+**Solution:** "Produce first drafts at ~80% voice accuracy using Voice DNA Documents. Use when you have a Voice DNA Document and need to draft content in that writer's authentic voice."
+
+### Duplicated Content
+
+Information should live in one place.
+
+**Problem:** Same content in SKILL.md and references
+
+**Solution:** Core in SKILL.md, depth in references, never both
+
+---
+
+## Template
+
+```yaml
+---
+name: skill-name
+description: Clear, comprehensive description of what this skill does and when to use it. Include trigger words and contexts. At least 20 characters.
+---
+
+# Skill Name
+
+[One-paragraph overview]
+
+## Core Philosophy
+
+[2-5 guiding principles]
+
+## Session Flow
+
+### Session Start
+[What happens first]
+
+### During Session
+[Key behaviors and activities]
+
+### Session End
+[How sessions conclude]
+
+## Inputs
+
+[What the skill needs]
+
+## Outputs
+
+[What the skill produces]
+
+## References
+
+[Pointers to bundled resources, when to load each]
+
+## Key Reminders
+
+[Critical points, common pitfalls to avoid]
+```
+
+---
+
+## Related
+
+- [Skill Anatomy](skill-anatomy.md) — Overall structure
+- [References & Assets](references-and-assets.md) — Bundling resources
+- [Building & Packaging](building-and-packaging.md) — Create .skill files

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,0 +1,49 @@
+# Getting Started
+
+Welcome to Claude Skills! This guide will help you get up and running quickly.
+
+---
+
+## Choose Your Path
+
+<div class="grid cards" markdown>
+
+-   :material-console:{ .lg .middle } **Claude Code (CLI)**
+
+    ---
+
+    For developers using the Claude Code command-line tool. Reference skills directly via filesystem paths.
+
+    [:octicons-arrow-right-24: Claude Code Setup](installation-claude-code.md)
+
+-   :material-web:{ .lg .middle } **Claude.ai (Web/Mobile/Desktop)**
+
+    ---
+
+    For using skills in the Claude web interface, mobile app, or desktop application.
+
+    [:octicons-arrow-right-24: Claude.ai Setup](installation-claude-ai.md)
+
+</div>
+
+---
+
+## Quick Overview
+
+### What You'll Learn
+
+1. **[What Are Skills?](what-are-skills.md)** — Understanding how skills extend Claude's capabilities
+2. **Installation** — Setting up skills for your preferred platform
+3. **[Your First Skill](your-first-skill.md)** — A hands-on tutorial using the Brainstorm skill
+
+### Prerequisites
+
+- Access to Claude (either Claude Code CLI or Claude.ai)
+- Basic familiarity with markdown (helpful but not required)
+- For Claude Code: Python 3.8+ (for packaging skills)
+
+---
+
+## Next Steps
+
+After installation, try the [Your First Skill](your-first-skill.md) tutorial to see skills in action with a real brainstorming session.

--- a/docs/getting-started/installation-claude-ai.md
+++ b/docs/getting-started/installation-claude-ai.md
@@ -21,9 +21,13 @@ git clone https://github.com/robertguss/claude-skills.git
 cd claude-skills
 ```
 
-### Step 2: Install Build Dependencies
+### Step 2: Install Dependencies
 
 ```bash
+# Using uv (recommended)
+uv sync
+
+# Or using pip
 pip install pyyaml
 ```
 
@@ -34,6 +38,10 @@ Use the build script to create a `.skill` package:
 === "Single Skill"
 
     ```bash
+    # Using just
+    just package brainstorm
+
+    # Or directly
     python build.py brainstorm
     ```
 
@@ -42,6 +50,10 @@ Use the build script to create a `.skill` package:
 === "All Skills"
 
     ```bash
+    # Using just
+    just package-all
+
+    # Or directly
     python build.py --all
     ```
 
@@ -50,6 +62,10 @@ Use the build script to create a `.skill` package:
 === "List Available Skills"
 
     ```bash
+    # Using just
+    just list-skills
+
+    # Or directly
     python build.py --list
     ```
 

--- a/docs/getting-started/installation-claude-ai.md
+++ b/docs/getting-started/installation-claude-ai.md
@@ -1,0 +1,177 @@
+# Claude.ai Setup
+
+This guide covers installing and using skills with Claude.ai (web, mobile, and desktop apps).
+
+---
+
+## Prerequisites
+
+- Claude.ai account with access to Skills feature
+- Python 3.8+ (for packaging skills)
+- The claude-skills repository cloned locally
+
+---
+
+## Installation
+
+### Step 1: Clone the Repository
+
+```bash
+git clone https://github.com/robertguss/claude-skills.git
+cd claude-skills
+```
+
+### Step 2: Install Build Dependencies
+
+```bash
+pip install pyyaml
+```
+
+### Step 3: Package a Skill
+
+Use the build script to create a `.skill` package:
+
+=== "Single Skill"
+
+    ```bash
+    python build.py brainstorm
+    ```
+
+    This creates `dist/brainstorm.skill`.
+
+=== "All Skills"
+
+    ```bash
+    python build.py --all
+    ```
+
+    This packages all skills into the `dist/` folder.
+
+=== "List Available Skills"
+
+    ```bash
+    python build.py --list
+    ```
+
+    Shows all available skills with validation status.
+
+### Step 4: Upload to Claude.ai
+
+1. Open [Claude.ai](https://claude.ai)
+2. Go to **Settings** (gear icon)
+3. Navigate to **Skills**
+4. Click **Upload Skill**
+5. Select the `.skill` file from the `dist/` folder
+6. The skill is now available in your Claude.ai sessions
+
+---
+
+## Usage
+
+### Starting a Skill Session
+
+Simply describe what you want to do:
+
+```
+Let's brainstorm some ideas for a new mobile app.
+```
+
+Claude will recognize the intent and apply the skill's workflow.
+
+### Skill Management
+
+In Claude.ai Settings → Skills, you can:
+
+- **View installed skills** — See all your active skills
+- **Remove skills** — Delete skills you no longer need
+- **Update skills** — Upload a new version to replace the old one
+
+---
+
+## Updating Skills
+
+When skills are updated in the repository:
+
+1. Pull the latest changes:
+   ```bash
+   cd /path/to/claude-skills
+   git pull
+   ```
+
+2. Re-package the skill:
+   ```bash
+   python build.py brainstorm
+   ```
+
+3. Upload the new `.skill` file in Claude.ai Settings → Skills
+
+---
+
+## Pipeline Skills
+
+For skills that work in sequence (like the Non-Fiction Book Factory), upload each skill you need:
+
+```bash
+python build.py book-ideation
+python build.py book-idea-validator
+python build.py book-market-research
+python build.py book-architect
+python build.py book-research-assistant
+python build.py chapter-architect
+```
+
+Then upload each `.skill` file to Claude.ai.
+
+---
+
+## What Gets Packaged
+
+The `.skill` file is a ZIP archive containing:
+
+- `SKILL.md` — The core instructions
+- `references/` — Supporting documentation (if present)
+- `assets/` — Templates and examples (if present)
+
+Hidden files, `.DS_Store`, and `__pycache__` are automatically excluded.
+
+---
+
+## Troubleshooting
+
+### Build Errors
+
+**"Missing required field: name"**
+
+The skill's `SKILL.md` is missing required YAML frontmatter. Each SKILL.md must start with:
+
+```yaml
+---
+name: skill-name
+description: A description of at least 20 characters explaining what the skill does.
+---
+```
+
+**"Description must be at least 20 characters"**
+
+The description in the frontmatter is too short. Provide a meaningful description.
+
+### Upload Errors
+
+**"Invalid skill file"**
+
+The `.skill` file may be corrupted. Try re-packaging:
+
+```bash
+python build.py <skill-name>
+```
+
+**"Skill already exists"**
+
+Remove the existing skill in Settings → Skills before uploading the updated version, or use the update/replace option if available.
+
+---
+
+## Next Steps
+
+- [:octicons-arrow-right-24: Your First Skill Tutorial](your-first-skill.md) — Try the Brainstorm skill hands-on
+- [:octicons-arrow-right-24: Browse Available Skills](../skills/index.md) — See all available skills

--- a/docs/getting-started/installation-claude-ai.md
+++ b/docs/getting-started/installation-claude-ai.md
@@ -88,7 +88,7 @@ Use the build script to create a `.skill` package:
 
 Simply describe what you want to do:
 
-```
+```text
 Let's brainstorm some ideas for a new mobile app.
 ```
 
@@ -156,7 +156,7 @@ Hidden files, `.DS_Store`, and `__pycache__` are automatically excluded.
 
 ### Build Errors
 
-**"Missing required field: name"**
+#### "Missing required field: name"
 
 The skill's `SKILL.md` is missing required YAML frontmatter. Each SKILL.md must start with:
 
@@ -167,13 +167,13 @@ description: A description of at least 20 characters explaining what the skill d
 ---
 ```
 
-**"Description must be at least 20 characters"**
+#### "Description must be at least 20 characters"
 
 The description in the frontmatter is too short. Provide a meaningful description.
 
 ### Upload Errors
 
-**"Invalid skill file"**
+#### "Invalid skill file"
 
 The `.skill` file may be corrupted. Try re-packaging:
 
@@ -181,7 +181,7 @@ The `.skill` file may be corrupted. Try re-packaging:
 python build.py <skill-name>
 ```
 
-**"Skill already exists"**
+#### "Skill already exists"
 
 Remove the existing skill in Settings → Skills before uploading the updated version, or use the update/replace option if available.
 

--- a/docs/getting-started/installation-claude-code.md
+++ b/docs/getting-started/installation-claude-code.md
@@ -1,0 +1,176 @@
+# Claude Code Setup
+
+This guide covers installing and using skills with Claude Code (the CLI tool).
+
+---
+
+## Prerequisites
+
+- [Claude Code](https://claude.ai/code) installed and configured
+- Git (for cloning the repository)
+- Python 3.8+ (optional, for packaging skills)
+
+---
+
+## Installation
+
+### Step 1: Clone the Repository
+
+```bash
+git clone https://github.com/robertguss/claude-skills.git
+cd claude-skills
+```
+
+Note the full path to this directory—you'll need it for configuration.
+
+### Step 2: Configure Skill References
+
+Add skill references to your `CLAUDE.md` file. You have two options:
+
+=== "Project-Level (Recommended)"
+
+    Add to your project's `CLAUDE.md`:
+
+    ```markdown
+    # CLAUDE.md
+
+    ## Skills
+
+    When brainstorming, read and follow /path/to/claude-skills/brainstorm/SKILL.md.
+
+    When working on book ideas, read and follow /path/to/claude-skills/non-fiction-book-factory/book-ideation/SKILL.md.
+    ```
+
+    This makes skills available only in that project.
+
+=== "Global"
+
+    Add to `~/.claude/CLAUDE.md`:
+
+    ```markdown
+    # CLAUDE.md
+
+    ## Skills
+
+    When brainstorming, read and follow /path/to/claude-skills/brainstorm/SKILL.md.
+    ```
+
+    This makes skills available in all your Claude Code sessions.
+
+---
+
+## Usage Patterns
+
+### Basic Invocation
+
+Simply describe what you want to do, and Claude will follow the skill:
+
+```
+Let's brainstorm some ideas for a new SaaS product.
+```
+
+Claude will:
+
+1. Recognize this matches the brainstorm skill
+2. Load the SKILL.md instructions
+3. Follow the prescribed workflow (asking about new vs. continuing, session energy, mode selection, etc.)
+
+### Explicit Skill Reference
+
+You can also explicitly reference a skill:
+
+```
+Using the brainstorm skill, help me think through newsletter content ideas.
+```
+
+### Pipeline Workflows
+
+For skills that work in sequence, progress through the pipeline:
+
+```markdown
+## Book Project Skills
+
+When developing book ideas, read and follow /path/to/claude-skills/non-fiction-book-factory/book-ideation/SKILL.md.
+
+When validating book concepts, read and follow /path/to/claude-skills/non-fiction-book-factory/book-idea-validator/SKILL.md.
+
+When researching book market viability, read and follow /path/to/claude-skills/non-fiction-book-factory/book-market-research/SKILL.md.
+```
+
+---
+
+## File Management
+
+Skills create versioned documents in your project. Recommended structure:
+
+```
+your-project/
+├── CLAUDE.md           # Skill references
+├── brainstorms/        # Brainstorming projects
+│   ├── _parking-lot.md
+│   └── project-name/
+│       ├── _index.md
+│       └── project-name-v1.md
+├── book-projects/      # Book development
+│   └── my-book/
+│       ├── concept-v1.md
+│       └── ...
+```
+
+---
+
+## Tips
+
+### Keep Skills Updated
+
+```bash
+cd /path/to/claude-skills
+git pull
+```
+
+### Use Absolute Paths
+
+Always use absolute paths in your `CLAUDE.md` references to avoid path resolution issues:
+
+```markdown
+# Good
+When brainstorming, read and follow /Users/you/claude-skills/brainstorm/SKILL.md.
+
+# Avoid (may not resolve correctly)
+When brainstorming, read and follow ../claude-skills/brainstorm/SKILL.md.
+```
+
+### Combine Multiple Skills
+
+You can reference multiple skills in a single project:
+
+```markdown
+## Skills
+
+When brainstorming, read and follow /path/to/claude-skills/brainstorm/SKILL.md.
+
+When capturing my writing voice, read and follow /path/to/claude-skills/writing/writing-dna-discovery/SKILL.md.
+
+When ghost writing content, read and follow /path/to/claude-skills/writing/ghost-writer/SKILL.md.
+```
+
+---
+
+## Troubleshooting
+
+### Skill Not Loading
+
+- Verify the path is correct and absolute
+- Check that the SKILL.md file exists at the specified location
+- Ensure your `CLAUDE.md` is in the project root or `~/.claude/`
+
+### References Not Found
+
+Skills reference their own `references/` folder. These paths are relative to the skill, so they should work automatically. If you see errors about missing references, the skill installation may be incomplete.
+
+---
+
+## Next Steps
+
+- [:octicons-arrow-right-24: Your First Skill Tutorial](your-first-skill.md) — Try the Brainstorm skill hands-on
+- [:octicons-arrow-right-24: Browse Available Skills](../skills/index.md) — See all available skills

--- a/docs/getting-started/installation-claude-code.md
+++ b/docs/getting-started/installation-claude-code.md
@@ -6,7 +6,8 @@ This guide covers installing and using skills with Claude Code (the CLI tool).
 
 ## Prerequisites
 
-- [Claude Code](https://claude.ai/code) installed and configured
+- **Node.js 18+** (required for Claude Code CLI)
+- **Claude Code CLI**: Install via `npm install -g @anthropic-ai/claude-code` ([setup guide](https://docs.anthropic.com/en/docs/claude-code/getting-started))
 - Git (for cloning the repository)
 - Python 3.8+ (optional, for packaging skills)
 

--- a/docs/getting-started/what-are-skills.md
+++ b/docs/getting-started/what-are-skills.md
@@ -1,0 +1,140 @@
+# What Are Skills?
+
+Skills are modular packages that transform Claude from a general-purpose assistant into a specialized collaborator for specific domains and workflows.
+
+---
+
+## The Problem Skills Solve
+
+Claude is incredibly capable out of the box, but for complex, domain-specific work, you often need to:
+
+- Explain your workflow every time
+- Remind Claude of best practices and frameworks
+- Provide templates for consistent output
+- Reference detailed documentation repeatedly
+
+Skills solve this by packaging all of that context into a reusable module that Claude can load on-demand.
+
+---
+
+## What's Inside a Skill?
+
+Each skill contains three types of content:
+
+### 1. Instructions (SKILL.md)
+
+The core of every skill. This file contains:
+
+- **Workflow guidance** — How to approach the domain step-by-step
+- **Decision frameworks** — When to use different methods or approaches
+- **Quality standards** — What good output looks like
+- **Session patterns** — How to start, progress, and end sessions
+
+### 2. Reference Documentation (references/)
+
+Deep knowledge that Claude loads on-demand to preserve context:
+
+- Detailed method explanations
+- Domain-specific frameworks
+- Best practices and anti-patterns
+- Research and evidence
+
+### 3. Templates (assets/)
+
+Structured formats for consistent output:
+
+- Project document templates
+- Tracker templates
+- Report formats
+- Handoff documents
+
+---
+
+## How Skills Work
+
+```mermaid
+flowchart LR
+    A[User Request] --> B{Skill Activated}
+    B --> C[Load SKILL.md]
+    C --> D[Follow Workflow]
+    D --> E{Need Details?}
+    E -->|Yes| F[Load Reference]
+    F --> D
+    E -->|No| G[Produce Output]
+    G --> H[Use Template]
+```
+
+1. **Activation** — When your request matches a skill's domain, Claude loads the skill
+2. **Workflow** — Claude follows the skill's prescribed approach
+3. **Progressive Disclosure** — Detailed references load only when needed
+4. **Structured Output** — Templates ensure consistent, useful deliverables
+
+---
+
+## Types of Skills
+
+### Standalone Skills
+
+Self-contained skills for specific tasks:
+
+- **Brainstorm** — Multi-session ideation with versioned documents
+
+### Pipeline Skills
+
+Skills designed to work together in sequence:
+
+- **Non-Fiction Book Factory** — From idea → validation → market research → architecture → chapters
+- **Ebook Factory** — From discovery → concept development
+- **Writing** — From voice DNA discovery → ghost writing
+
+Pipeline skills pass structured "handoff documents" between stages, ensuring continuity and quality.
+
+---
+
+## Key Concepts
+
+### Session Continuity
+
+Many skills support multi-session workflows spanning days or weeks. They do this through:
+
+- **Versioned documents** — Each session creates a new version (v1, v2, v3...)
+- **Session logs** — Track what happened when
+- **Decision logs** — Capture reasoning, not just conclusions
+
+### Modes
+
+Some skills offer different operating modes:
+
+- **Connected mode** — Claude surfaces connections to other work
+- **Clean-slate mode** — Fresh thinking without prior context
+- **Quick mode** — Rapid progress vs. deep exploration
+
+### Handoffs
+
+Pipeline skills produce structured handoff documents that:
+
+- Summarize what was accomplished
+- Meet explicit readiness criteria
+- Provide everything the next skill needs
+
+---
+
+## Benefits of Using Skills
+
+| Without Skills | With Skills |
+|----------------|-------------|
+| Explain workflow each time | Workflow is pre-defined |
+| Inconsistent output format | Templates ensure consistency |
+| Context lost between sessions | Versioned documents maintain history |
+| Ad-hoc quality standards | Built-in quality checks |
+| Generic responses | Domain-specialized collaboration |
+
+---
+
+## Next Steps
+
+Ready to start using skills?
+
+- [:octicons-arrow-right-24: Claude Code Setup](installation-claude-code.md)
+- [:octicons-arrow-right-24: Claude.ai Setup](installation-claude-ai.md)
+- [:octicons-arrow-right-24: Your First Skill Tutorial](your-first-skill.md)

--- a/docs/getting-started/your-first-skill.md
+++ b/docs/getting-started/your-first-skill.md
@@ -1,0 +1,216 @@
+# Your First Skill
+
+Let's use the Brainstorm skill to see how skills work in practice. This tutorial takes about 10 minutes.
+
+---
+
+## What You'll Experience
+
+The Brainstorm skill demonstrates key skill concepts:
+
+- **Structured workflow** — Guided session start, middle, and end
+- **Collaborative partnership** — Claude pushes back and asks hard questions
+- **Versioned documents** — Your ideas are captured and organized
+- **Session continuity** — Pick up where you left off days or weeks later
+
+---
+
+## Before You Start
+
+Make sure you have:
+
+- Skills installed ([Claude Code](installation-claude-code.md) or [Claude.ai](installation-claude-ai.md))
+- A topic you'd like to brainstorm (or use our example)
+
+---
+
+## Step 1: Start a Session
+
+Begin by telling Claude you want to brainstorm:
+
+```
+Let's brainstorm ideas for a productivity app for remote workers.
+```
+
+Claude will recognize this matches the Brainstorm skill and begin the structured workflow.
+
+---
+
+## Step 2: Answer the Setup Questions
+
+Claude will ask several questions to configure the session:
+
+### New or Continuing?
+
+```
+Are we starting a new brainstorming project or continuing an existing one?
+```
+
+Answer: **New** (for this tutorial)
+
+### Session Energy
+
+```
+Deep exploration today or quick progress?
+```
+
+Choose based on your available time:
+
+- **Deep exploration** — More questions, more methods, thorough analysis
+- **Quick progress** — Focused, efficient, fewer tangents
+
+### Mode Selection
+
+```
+Connected mode or clean-slate mode?
+```
+
+- **Connected mode** — Claude surfaces connections to your other work
+- **Clean-slate mode** — Fresh thinking without prior context
+
+For this tutorial, either works.
+
+### Context Confirmation
+
+Claude will confirm the brainstorming context:
+
+```
+It sounds like you're wanting to brainstorm a new software product. Does that sound right?
+```
+
+Confirm or clarify as needed.
+
+---
+
+## Step 3: Brainstorm
+
+Now the real work begins. Notice how Claude:
+
+**Asks probing questions:**
+```
+"Who specifically is the target user? A freelancer working from coffee shops
+or a corporate employee in a home office?"
+```
+
+**Suggests frameworks when helpful:**
+```
+"We're generating lots of ideas—want to try affinity grouping to organize them?"
+```
+
+**Pushes back on weak reasoning:**
+```
+"I'm not convinced that feature solves the core problem. Here's why..."
+```
+
+**Marks decision points:**
+```
+"This feels like a decision point. Should we log: 'Target user is freelancers
+with variable schedules'?"
+```
+
+---
+
+## Step 4: End the Session
+
+When you're ready to wrap up, say:
+
+```
+Let's wrap up for today.
+```
+
+Claude will provide:
+
+### Exit Summary
+
+A crisp recap of:
+
+- Current state of the project
+- Key decisions made (with reasoning)
+- Open questions remaining
+- Suggested next steps
+
+### The Overnight Test
+
+```
+"What question should you sit with before our next session?"
+```
+
+A thought-provoking question to percolate between sessions.
+
+### Version Document
+
+Claude creates a versioned document (v1) capturing everything from the session:
+
+```markdown
+# Productivity App - v1
+
+## Quick Context
+Brainstorming a productivity app for remote freelancers...
+
+## Session Log
+- Date: 2024-01-15
+- Duration: 45 min
+- Energy: Deep exploration
+- Mode: Clean-slate
+- Methods used: Free association, SCAMPER
+
+## Current Thinking
+[The substance of where things stand]
+
+## Ideas Inventory
+### Developing
+- Flexible time blocking that adapts to energy levels
+- Integration with freelance platforms for project-aware scheduling
+
+### Raw
+- AI-powered focus mode
+- Social accountability features
+
+## Decisions Made
+1. Target user is freelancers with variable schedules
+   - Reasoning: Corporate remote workers already have Teams/Slack...
+
+## Open Questions
+- How to handle timezone complexity?
+- Native app vs. web-first?
+
+## Next Steps
+1. Research existing solutions for freelancers
+2. Interview 3-5 freelancers about pain points
+```
+
+---
+
+## Step 5: Continue Later
+
+Days or weeks later, return and say:
+
+```
+Let's continue brainstorming the productivity app.
+```
+
+Claude will ask for the latest version file. Provide it, and the session picks up exactly where you left off—with full context of previous decisions, open questions, and ideas.
+
+---
+
+## What You Learned
+
+In this tutorial, you experienced:
+
+| Skill Feature | What You Saw |
+|---------------|--------------|
+| Structured workflow | Setup questions, checkpoints, exit summary |
+| Collaborative partnership | Probing questions, pushback, suggestions |
+| Versioned documents | v1 document capturing the session |
+| Session continuity | Clear handoff for future sessions |
+| Method integration | Framework suggestions when appropriate |
+
+---
+
+## Next Steps
+
+Now that you've experienced a skill in action:
+
+- [:octicons-arrow-right-24: Explore the Brainstorm skill](../skills/brainstorm/index.md) — Full documentation
+- [:octicons-arrow-right-24: Browse all skills](../skills/index.md) — Find skills for your needs
+- [:octicons-arrow-right-24: Learn about pipelines](../concepts/pipelines.md) — Skills that work together

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,95 @@
+# Claude Skills
+
+A collection of custom skills that extend Claude's capabilities with specialized workflows, methods, and domain knowledge.
+
+---
+
+## What Are Skills?
+
+Skills are modular packages that transform Claude from a general-purpose assistant into a specialized collaborator. Each skill contains:
+
+- **Instructions** - Detailed guidance for specific domains and workflows
+- **Reference documentation** - Deep knowledge loaded on-demand
+- **Templates** - Structured output formats for consistent results
+
+Skills work with both **Claude Code** (CLI) and **Claude.ai** (web/mobile/desktop).
+
+---
+
+## Skill Categories
+
+<div class="grid cards" markdown>
+
+-   :material-lightbulb-outline:{ .lg .middle } **Brainstorm**
+
+    ---
+
+    Collaborative multi-session brainstorming with versioned documents, 25+ thinking methods, and decision tracking.
+
+    [:octicons-arrow-right-24: Explore Brainstorm](skills/brainstorm/index.md)
+
+-   :material-book-open-variant:{ .lg .middle } **Non-Fiction Book Factory**
+
+    ---
+
+    A complete pipeline for developing nonfiction books—from raw idea to chapter-level architecture.
+
+    [:octicons-arrow-right-24: Explore Book Factory](skills/non-fiction-book-factory/index.md)
+
+-   :material-book-edit:{ .lg .middle } **Ebook Factory**
+
+    ---
+
+    Create focused ebooks—shorter, concentrated solutions optimized for speed-to-value.
+
+    [:octicons-arrow-right-24: Explore Ebook Factory](skills/ebook-factory/index.md)
+
+-   :material-feather:{ .lg .middle } **Writing**
+
+    ---
+
+    Capture and replicate authentic writing voices with DNA discovery and ghost writing.
+
+    [:octicons-arrow-right-24: Explore Writing](skills/writing/index.md)
+
+</div>
+
+---
+
+## Quick Start
+
+=== "Claude Code (CLI)"
+
+    Reference skills in your project's `CLAUDE.md` or global `~/.claude/CLAUDE.md`:
+
+    ```markdown
+    # CLAUDE.md
+
+    ## Skills
+
+    When brainstorming, read and follow /path/to/claude-skills/brainstorm/SKILL.md.
+    ```
+
+    [:octicons-arrow-right-24: Full Claude Code setup guide](getting-started/installation-claude-code.md)
+
+=== "Claude.ai (Web/Mobile/Desktop)"
+
+    1. Package the skill: `python build.py <skill-name>`
+    2. Open Claude.ai → Settings → Skills
+    3. Upload the `.skill` file from `dist/`
+
+    [:octicons-arrow-right-24: Full Claude.ai setup guide](getting-started/installation-claude-ai.md)
+
+---
+
+## For Developers
+
+Want to create your own skills or contribute to this collection?
+
+[:octicons-arrow-right-24: Developer Guide](developer-guide/index.md) — Learn the anatomy of a skill, best practices, and how to package for distribution.
+
+---
+
+## License
+
+Personal use. Modify freely.

--- a/docs/reference/build-commands.md
+++ b/docs/reference/build-commands.md
@@ -1,0 +1,247 @@
+# Build Commands
+
+CLI reference for the build.py packaging script.
+
+---
+
+## Overview
+
+The `build.py` script packages skills for Claude.ai upload. It validates skill structure, creates ZIP archives, and outputs `.skill` files to the `dist/` directory.
+
+---
+
+## Prerequisites
+
+```bash
+# Install required dependency
+pip install pyyaml
+```
+
+---
+
+## Commands
+
+### Package a Single Skill
+
+```bash
+python build.py <skill-name>
+```
+
+**Example:**
+```bash
+python build.py brainstorm
+```
+
+**Output:**
+```
+Packaging brainstorm...
+Created: dist/brainstorm.skill
+```
+
+### Package All Skills
+
+```bash
+python build.py --all
+```
+
+**Output:**
+```
+Packaging brainstorm...
+Created: dist/brainstorm.skill
+Packaging book-ideation...
+Created: dist/book-ideation.skill
+...
+Packaged 12 skills successfully.
+```
+
+### List Available Skills
+
+```bash
+python build.py --list
+```
+
+**Output:**
+```
+Available skills:
+  brainstorm             ✓ valid
+  book-ideation          ✓ valid
+  book-idea-validator    ✓ valid
+  book-market-research   ✓ valid
+  book-architect         ✓ valid
+  book-research-assistant ✓ valid
+  chapter-architect      ✓ valid
+  ebook-discovery        ✓ valid
+  ebook-concept-development ✓ valid
+  writing-dna-discovery  ✓ valid
+  ghost-writer           ✓ valid
+```
+
+---
+
+## Skill Naming
+
+Skill names for the build command match their folder names:
+
+| Folder Path | Build Command |
+|-------------|---------------|
+| `brainstorm/` | `python build.py brainstorm` |
+| `non-fiction-book-factory/book-ideation/` | `python build.py book-ideation` |
+| `ebook-factory/ebook-discovery/` | `python build.py ebook-discovery` |
+| `writing/ghost-writer/` | `python build.py ghost-writer` |
+
+---
+
+## Output
+
+### Location
+
+All packaged skills are output to the `dist/` directory:
+
+```
+dist/
+├── brainstorm.skill
+├── book-ideation.skill
+├── book-idea-validator.skill
+└── ...
+```
+
+### File Format
+
+`.skill` files are ZIP archives containing:
+
+- `SKILL.md` — The core instructions
+- `references/` — Supporting documentation (if present)
+- `assets/` — Templates and examples (if present)
+
+### Excluded Files
+
+The following are automatically excluded from packages:
+
+- Hidden files (starting with `.`)
+- `.DS_Store`
+- `__pycache__`
+- `README.md` (skill-level)
+
+---
+
+## Validation
+
+The build script validates each skill before packaging:
+
+### Required Elements
+
+| Element | Requirement |
+|---------|-------------|
+| `SKILL.md` | Must exist in skill folder |
+| YAML frontmatter | Must be present at top of SKILL.md |
+| `name` field | Required in frontmatter |
+| `description` field | Required, minimum 20 characters |
+
+### Validation Errors
+
+**Missing SKILL.md:**
+```
+Error: brainstorm/SKILL.md not found
+```
+
+**Missing frontmatter:**
+```
+Error: SKILL.md must start with YAML frontmatter (---)
+```
+
+**Missing required field:**
+```
+Error: Missing required field: name
+```
+
+**Description too short:**
+```
+Error: Description must be at least 20 characters
+```
+
+---
+
+## SKILL.md Frontmatter
+
+Each SKILL.md must begin with YAML frontmatter:
+
+```yaml
+---
+name: skill-name
+description: A description of at least 20 characters explaining what the skill does and when to use it.
+---
+
+# Skill Title
+
+Content...
+```
+
+### Frontmatter Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Skill identifier (should match folder name) |
+| `description` | Yes | When to activate the skill (min 20 chars) |
+
+The `description` field is particularly important—it determines when Claude activates the skill based on user prompts.
+
+---
+
+## Workflow
+
+### Typical Packaging Workflow
+
+1. **Validate** — Ensure skill is valid
+   ```bash
+   python build.py --list
+   ```
+
+2. **Package** — Create the .skill file
+   ```bash
+   python build.py brainstorm
+   ```
+
+3. **Upload** — Go to Claude.ai → Settings → Skills → Upload
+
+### Updating a Skill
+
+1. Make changes to the skill files
+2. Re-run the build command
+3. Upload the new .skill file to Claude.ai (replaces existing)
+
+---
+
+## Troubleshooting
+
+### "Skill not found"
+
+The skill name doesn't match any folder. Check:
+
+- Spelling
+- That you're using the skill name, not the folder path
+- Run `python build.py --list` to see valid names
+
+### "Invalid YAML frontmatter"
+
+The frontmatter is malformed. Ensure:
+
+- Frontmatter starts and ends with `---`
+- YAML is properly formatted
+- Required fields are present
+
+### "Permission denied" on dist/
+
+The dist folder may have permission issues:
+
+```bash
+mkdir -p dist
+chmod 755 dist
+```
+
+---
+
+## Related
+
+- [Claude.ai Setup](../getting-started/installation-claude-ai.md) — Full upload workflow
+- [Skill Anatomy](../developer-guide/skill-anatomy.md) — Understanding skill structure
+- [Writing SKILL.md](../developer-guide/writing-skill-md.md) — Best practices for SKILL.md

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,53 @@
+# Reference
+
+Quick reference documentation for Claude Skills.
+
+---
+
+## Reference Documents
+
+<div class="grid cards" markdown>
+
+-   :material-table:{ .lg .middle } **[Skill Catalog](skill-catalog.md)**
+
+    ---
+
+    Complete table of all skills with descriptions, inputs, outputs, and pipeline positions.
+
+-   :material-console:{ .lg .middle } **[Build Commands](build-commands.md)**
+
+    ---
+
+    CLI reference for the build.py packaging script.
+
+</div>
+
+---
+
+## Quick Links
+
+### By Task
+
+| I want to... | Go to... |
+|--------------|----------|
+| See all available skills | [Skill Catalog](skill-catalog.md) |
+| Package a skill for Claude.ai | [Build Commands](build-commands.md) |
+| Understand skill structure | [Developer Guide](../developer-guide/skill-anatomy.md) |
+| Learn about pipelines | [Concepts: Pipelines](../concepts/pipelines.md) |
+
+### By Skill Category
+
+| Category | Skills |
+|----------|--------|
+| Standalone | [Brainstorm](../skills/brainstorm/index.md) |
+| Book Factory | [6 skills](../skills/non-fiction-book-factory/index.md) |
+| Ebook Factory | [2 skills](../skills/ebook-factory/index.md) |
+| Writing | [2 skills](../skills/writing/index.md) |
+
+---
+
+## External Resources
+
+- [GitHub Repository](https://github.com/robertguss/claude-skills)
+- [Claude Code Documentation](https://claude.ai/code)
+- [Claude.ai](https://claude.ai)

--- a/docs/reference/skill-catalog.md
+++ b/docs/reference/skill-catalog.md
@@ -1,0 +1,208 @@
+# Skill Catalog
+
+Complete reference of all available skills.
+
+---
+
+## All Skills at a Glance
+
+| Skill | Category | Description |
+|-------|----------|-------------|
+| [brainstorm](../skills/brainstorm/index.md) | Standalone | Multi-session ideation with 25+ thinking methods |
+| [book-ideation](../skills/non-fiction-book-factory/book-ideation.md) | Book Factory | Develop raw ideas into structured book concepts |
+| [book-idea-validator](../skills/non-fiction-book-factory/book-idea-validator.md) | Book Factory | Stress-test concepts against research |
+| [book-market-research](../skills/non-fiction-book-factory/book-market-research.md) | Book Factory | Assess commercial viability for Amazon KDP |
+| [book-architect](../skills/non-fiction-book-factory/book-architect.md) | Book Factory | Design structural and emotional architecture |
+| [book-research-assistant](../skills/non-fiction-book-factory/book-research-assistant.md) | Book Factory | Plan, orchestrate, and validate deep research |
+| [chapter-architect](../skills/non-fiction-book-factory/chapter-architect.md) | Book Factory | Plan chapters at beat-level granularity |
+| [ebook-discovery](../skills/ebook-factory/ebook-discovery.md) | Ebook Factory | Surface ebook ideas from various sources |
+| [ebook-concept-development](../skills/ebook-factory/ebook-concept-development.md) | Ebook Factory | Develop ideas into structured concepts |
+| [writing-dna-discovery](../skills/writing/writing-dna-discovery.md) | Writing | Capture voice patterns through interview and analysis |
+| [ghost-writer](../skills/writing/ghost-writer.md) | Writing | Produce drafts at ~80% voice accuracy |
+
+---
+
+## Detailed Skill Reference
+
+### Standalone Skills
+
+#### brainstorm
+
+| Attribute | Value |
+|-----------|-------|
+| **Purpose** | Collaborative multi-session brainstorming |
+| **Inputs** | Topic/problem to brainstorm |
+| **Outputs** | Versioned project documents, decision logs |
+| **Pipeline** | None (standalone) |
+| **Modes** | Deep/Quick, Connected/Clean-slate |
+| **Multi-session** | Yes |
+
+---
+
+### Non-Fiction Book Factory
+
+#### book-ideation
+
+| Attribute | Value |
+|-----------|-------|
+| **Purpose** | Transform raw ideas into structured book concepts |
+| **Inputs** | Raw idea or brainstorm output |
+| **Outputs** | Book Concept Document (8 elements) |
+| **Pipeline Position** | First in Book Factory |
+| **Downstream** | book-idea-validator, book-market-research |
+| **Multi-session** | Yes |
+
+#### book-idea-validator
+
+| Attribute | Value |
+|-----------|-------|
+| **Purpose** | Stress-test concepts against existing research |
+| **Inputs** | Book Concept Document |
+| **Outputs** | Validation Report (Go/Revise/Kill) |
+| **Pipeline Position** | After book-ideation |
+| **Upstream** | book-ideation |
+| **Downstream** | book-market-research, book-architect |
+| **Multi-session** | Yes |
+
+#### book-market-research
+
+| Attribute | Value |
+|-----------|-------|
+| **Purpose** | Assess commercial viability for Amazon KDP |
+| **Inputs** | Book Concept Document, Validation Report (optional) |
+| **Outputs** | Market Research Report, Viability Scorecard |
+| **Pipeline Position** | After validation |
+| **Modes** | Quick Assessment, Deep Dive |
+| **Multi-session** | Yes (Deep Dive) |
+
+#### book-architect
+
+| Attribute | Value |
+|-----------|-------|
+| **Purpose** | Design structural and emotional architecture |
+| **Inputs** | Book Concept Document, Validation Report, Market Research Report |
+| **Outputs** | Master Architecture Document, Section Blueprints, Research Gaps |
+| **Pipeline Position** | After validation/market research |
+| **Downstream** | book-research-assistant, chapter-architect |
+| **Multi-session** | Yes |
+
+#### book-research-assistant
+
+| Attribute | Value |
+|-----------|-------|
+| **Purpose** | Plan, orchestrate, and validate deep research |
+| **Inputs** | Research Gaps Document, Architecture Documents |
+| **Outputs** | Research Prompts, Chapter Summaries, Final Synthesis |
+| **Pipeline Position** | After architecture |
+| **Phases** | Planning, Validation |
+| **Multi-session** | Yes |
+
+#### chapter-architect
+
+| Attribute | Value |
+|-----------|-------|
+| **Purpose** | Plan chapters at beat-level granularity |
+| **Inputs** | Architecture Document (chapter spec), Research Dossier |
+| **Outputs** | Chapter Outline Document |
+| **Pipeline Position** | After research |
+| **Downstream** | draft-coach, ghostwriter |
+| **Multi-session** | Optional |
+
+---
+
+### Ebook Factory
+
+#### ebook-discovery
+
+| Attribute | Value |
+|-----------|-------|
+| **Purpose** | Surface ebook ideas from various sources |
+| **Inputs** | Content inventory, expertise description, or fresh brainstorm |
+| **Outputs** | Discovery Tracker, Handoff Summary |
+| **Pipeline Position** | First in Ebook Factory |
+| **Entry Modes** | 11 different modes |
+| **Multi-session** | Yes |
+
+#### ebook-concept-development
+
+| Attribute | Value |
+|-----------|-------|
+| **Purpose** | Develop ideas into structured concepts |
+| **Inputs** | Ebook idea from any source |
+| **Outputs** | Ebook Concept Document (5 elements) |
+| **Pipeline Position** | After discovery |
+| **Downstream** | Ebook Architecture |
+| **Multi-session** | Yes |
+
+---
+
+### Writing
+
+#### writing-dna-discovery
+
+| Attribute | Value |
+|-----------|-------|
+| **Purpose** | Capture voice patterns through interview and analysis |
+| **Inputs** | Writing samples, author interview |
+| **Outputs** | Voice DNA Document |
+| **Pipeline Position** | First in Writing pipeline |
+| **Downstream** | ghost-writer |
+| **Multi-session** | Yes |
+
+#### ghost-writer
+
+| Attribute | Value |
+|-----------|-------|
+| **Purpose** | Produce drafts at ~80% voice accuracy |
+| **Inputs** | Voice DNA Document, content brief |
+| **Outputs** | 2 draft variations, confidence assessment |
+| **Pipeline Position** | After DNA discovery |
+| **Upstream** | writing-dna-discovery |
+| **Multi-session** | Yes |
+
+---
+
+## Skills by Feature
+
+### Multi-Session Support
+
+All skills support multi-session work with versioned documents:
+
+| Skill | Session Type |
+|-------|--------------|
+| brainstorm | Versioned project documents |
+| book-ideation | Versioned concept documents |
+| book-architect | Progress tracker + decision log |
+| book-research-assistant | Chapter trackers |
+| All others | Session-appropriate tracking |
+
+### Mode Support
+
+| Skill | Available Modes |
+|-------|-----------------|
+| brainstorm | Deep/Quick, Connected/Clean-slate |
+| book-market-research | Quick Assessment/Deep Dive, Author Intent |
+| book-research-assistant | Planning/Validation phases |
+| ebook-discovery | 11 entry modes |
+
+---
+
+## Pipeline Reference
+
+### Book Factory Pipeline
+
+```
+book-ideation → book-idea-validator → book-market-research → book-architect → book-research-assistant → chapter-architect
+```
+
+### Ebook Factory Pipeline
+
+```
+ebook-discovery → ebook-concept-development → [ebook-architecture]
+```
+
+### Writing Pipeline
+
+```
+writing-dna-discovery → ghost-writer
+```

--- a/docs/reference/skill-catalog.md
+++ b/docs/reference/skill-catalog.md
@@ -191,18 +191,18 @@ All skills support multi-session work with versioned documents:
 
 ### Book Factory Pipeline
 
-```
+```text
 book-ideation → book-idea-validator → book-market-research → book-architect → book-research-assistant → chapter-architect
 ```
 
 ### Ebook Factory Pipeline
 
-```
+```text
 ebook-discovery → ebook-concept-development → [ebook-architecture]
 ```
 
 ### Writing Pipeline
 
-```
+```text
 writing-dna-discovery → ghost-writer
 ```

--- a/docs/skills/brainstorm/index.md
+++ b/docs/skills/brainstorm/index.md
@@ -1,0 +1,316 @@
+# Brainstorm
+
+> Collaborative brainstorming partner for multi-session ideation projects. Use when you want to brainstorm, ideate, explore ideas, or think through problems -- whether for SaaS products, software tools, book ideas, newsletter content, business strategies, or any creative/analytical challenge.
+
+## Overview
+
+The Brainstorm skill transforms Claude into a genuine intellectual partner for ideation projects that span days or weeks. Unlike simple idea generation, this skill emphasizes collaborative thinking, proactive challenge of assumptions, and persistent documentation that maintains context across sessions.
+
+At its core, Brainstorm operates on the principle that good ideas emerge through dialogue, not dictation. Claude will bring observations and suggestions proactively, push back on weak reasoning, surface connections to other work (when desired), and ask the hard questions you might avoid. The human always decides, but the reasoning gets logged -- creating a rich record of the thinking process, not just the conclusions.
+
+The skill solves the fundamental problem of multi-session creative work: maintaining continuity. Through versioned markdown documents, structured session logs, and idea maturity tracking, you can pick up exactly where you left off -- whether that was yesterday or three weeks ago.
+
+## Quick Start
+
+### Prerequisites
+
+- Claude Code CLI or Claude.ai with skill upload capability
+- A folder where brainstorming project files will be stored
+
+### Basic Usage
+
+**For Claude Code**, reference the skill in your project's `CLAUDE.md`:
+
+```markdown
+## Skills
+
+- /path/to/brainstorm/SKILL.md
+```
+
+**For Claude.ai**, upload the packaged `.skill` file via Settings > Skills.
+
+**Sample prompt to begin:**
+
+```
+I want to brainstorm a new SaaS product idea. I've noticed that developer tools
+for API documentation are either too complex or too basic. Help me explore this space.
+```
+
+Claude will then ask the session-start questions to establish context and mode before diving in.
+
+## Features
+
+| Feature | Description |
+|---------|-------------|
+| **Multi-session continuity** | Versioned documents maintain full context across days or weeks |
+| **Idea maturity tracking** | Six-level system (Raw > Developing > Refined > Ready > Parked > Eliminated) |
+| **25+ thinking methods** | Curated catalog of divergent, convergent, and evaluative techniques |
+| **Session energy modes** | Deep exploration vs. quick progress -- adapts to your available time |
+| **Connected vs. clean-slate** | Cross-project awareness or fresh thinking without baggage |
+| **Decision logging** | Captures reasoning, not just conclusions |
+| **Disagreement protocol** | Structured approach when you and Claude see things differently |
+| **Parking lot** | Captures off-topic ideas for other projects |
+| **Synthesis generation** | Distills best thinking after multiple sessions |
+
+## Workflow
+
+### Session Start
+
+Every session begins with four orienting questions:
+
+1. **New or continuing?** -- "Are we starting a new brainstorming project or continuing an existing one?"
+   - If continuing: Claude asks for the latest version file
+   - If new: Proceeds to project initialization
+
+2. **Session energy** -- "Deep exploration today or quick progress?"
+
+3. **Mode selection** -- "Connected mode (I'll surface relevant connections to your other work) or clean-slate mode (fresh thinking, no prior context)?"
+
+4. **Context type** (new projects only) -- Claude identifies and confirms the brainstorming context, then recommends appropriate methods
+
+### During Session
+
+**Active collaboration behaviors:**
+
+- Proactive observations: "I notice you keep circling back to X -- want to dig into why?"
+- Direct challenges: "I'm not convinced by that reasoning. Here's why..."
+- Connection surfacing (connected mode): "This relates to what you explored in [other project]"
+- Hard questions the user might avoid
+- The "So What?" test: "Why does this matter? Who specifically cares?"
+
+**Decision checkpoints:**
+
+When a decision crystallizes, Claude explicitly marks it: "This feels like a decision point. Should we log: [decision statement]?" Both the decision and the reasoning are captured.
+
+**Method suggestions:**
+
+When structure would help: "We're stuck diverging -- want to try SCAMPER to force new angles?" or "Before we commit, should we run a pre-mortem?"
+
+**Pacing awareness:**
+
+At natural breakpoints (roughly 20-30 minutes of dense work), Claude checks in: "Want to keep going or pause here?"
+
+**Parking lot capture:**
+
+Off-topic ideas get flagged: "This seems relevant to [other project], not this one -- should I add it to the parking lot?"
+
+### Session End
+
+Every session concludes with three elements:
+
+1. **Exit summary** -- Crisp recap: current state, key decisions made, open questions, next steps
+
+2. **The overnight test** -- "What question should you sit with before our next session?"
+
+3. **Version creation** -- Claude generates the next version of the project document
+
+## Inputs & Outputs
+
+### Inputs
+
+| Input | Required | Description |
+|-------|----------|-------------|
+| Problem or topic | Yes | What you want to brainstorm |
+| Previous version file | For continuing sessions | The latest project document |
+| Session preferences | Prompted at start | Energy mode, connected/clean-slate, etc. |
+
+### Outputs
+
+| Output | Description |
+|--------|-------------|
+| **Project documents** | Versioned files (project-name-v1.md, v2.md, etc.) with full session content |
+| **Index file** | Changelog, decision log, and project trajectory per project |
+| **Parking lot** | Cross-project idea capture in `_parking-lot.md` |
+| **Exit summaries** | End-of-session recaps with overnight questions |
+
+**File structure:**
+
+```
+brainstorms/
+  _parking-lot.md              # Cross-project idea capture
+  project-name/
+    _index.md                  # Changelog and decision log
+    project-name-v1.md         # Version 1
+    project-name-v2.md         # Version 2
+    ...
+```
+
+## Best Practices
+
+**Start with clear success criteria.** Early in any project, establish: "What does 'done' look like for this brainstorm?" and "How will we know we've succeeded?"
+
+**Use version files, never overwrite.** Each session produces a new version. This creates a record of how thinking evolved and allows you to revisit earlier states.
+
+**Let Claude push back.** The skill is designed to challenge weak reasoning. If you find yourself defending ideas, that's the system working -- the best ideas survive scrutiny.
+
+**Log disagreements.** When you and Claude see things differently, both perspectives get captured. This often reveals important tensions worth exploring.
+
+**Match energy to time.** Deep exploration mode for open-ended sessions; quick progress mode when you need decisions, not divergence.
+
+**Request synthesis after 3+ sessions.** Claude will offer: "We've had [N] sessions on this. Want me to create a synthesis document that distills our current best thinking?"
+
+**Use Quick Capture Mode when time is short.** For rapid idea capture: dump the raw idea, answer 2-3 clarifying questions, get a minimal v1 document marked for expansion later.
+
+## Modes
+
+### Session Energy
+
+| Mode | Best For | Approach |
+|------|----------|----------|
+| **Deep exploration** | Long sessions, open-ended thinking, divergent work | Freely use divergent methods, allow tangents (park off-topic items), embrace ambiguity, end with synthesis not decisions |
+| **Quick progress** | Short sessions, need decisions, move forward | Clear scope upfront, primarily convergent methods, time-boxed divergence (10 min max), decisions get logged, end with next actions |
+
+### Context Awareness
+
+| Mode | Best For | Behavior |
+|------|----------|----------|
+| **Connected** (default) | Building on existing work, ensuring consistency, leveraging past thinking | Cross-references other projects: "This relates to your thinking on X," "This might conflict with what you decided about Y" |
+| **Clean-slate** | Genuinely new territory, avoiding anchoring, fresh perspectives | No references to other projects or prior work; useful when past approaches aren't working |
+
+## Methods Catalog
+
+The skill includes 25+ structured thinking methods organized by purpose:
+
+### Divergent Methods (Generate New Ideas)
+
+| Method | One-liner |
+|--------|-----------|
+| **SCAMPER** | Systematic prompts: Substitute, Combine, Adapt, Modify, Put to other uses, Eliminate, Reverse |
+| **Random Stimulus** | Introduce unrelated word/image, force connections |
+| **Forced Analogies** | "How would [X industry/person] solve this?" |
+| **Mind Mapping** | Visual branching from central concept |
+| **Worst Possible Idea** | Generate terrible ideas, then invert |
+| **TRIZ Principles** | 40 inventive principles for contradiction resolution |
+
+### Convergent Methods (Focus & Decide)
+
+| Method | One-liner |
+|--------|-----------|
+| **Affinity Grouping** | Cluster similar ideas, name the clusters |
+| **Dot Voting** | Allocate limited votes across options |
+| **Weighted Scoring** | Score options against weighted criteria |
+| **Elimination Rounds** | Progressive cuts with explicit criteria |
+| **2x2 Matrix** | Plot options on two key dimensions |
+
+### Problem-Framing Methods
+
+| Method | One-liner |
+|--------|-----------|
+| **First Principles** | Strip to basics, rebuild from ground truth |
+| **5 Whys** | Ask "why" repeatedly to find core issue |
+| **Inversion** | "What guarantees failure?" then avoid it |
+| **Problem Reframing** | Restate the problem 5 different ways |
+| **Jobs-to-be-Done** | What job is the user hiring this to do? |
+
+### Perspective Shift Methods
+
+| Method | One-liner |
+|--------|-----------|
+| **Six Thinking Hats** | Rotate through facts, feelings, risks, benefits, creativity, process |
+| **Steelman** | Build the strongest case for the opposing view |
+| **Audience Reality Check** | Would [specific person] actually want this? |
+| **Pre-mortem** | Assume it failed -- why? |
+| **Assumption Surfacing** | What are we taking for granted? |
+
+### Theological/Philosophical Methods
+
+| Method | One-liner |
+|--------|-----------|
+| **Presuppositional Analysis** | What worldview assumptions underlie this idea? |
+| **Telos Examination** | What is the ultimate end/purpose this serves? |
+| **Stewardship Frame** | Am I being a faithful steward of what's entrusted to me? |
+
+### Quick Selection Guide
+
+- **"I have no ideas"** -- Random Stimulus, Worst Possible Idea
+- **"I have too many ideas"** -- Affinity Grouping, Elimination Rounds
+- **"I'm not sure what the real problem is"** -- 5 Whys, Problem Reframing
+- **"This feels risky"** -- Pre-mortem, Inversion
+- **"Am I missing something?"** -- Six Thinking Hats, Steelman
+- **"Is this actually valuable?"** -- Jobs-to-be-Done, Audience Reality Check
+- **"What are we assuming?"** -- First Principles, Assumption Surfacing, Presuppositional Analysis
+
+## Idea Maturity Levels
+
+Ideas move through six maturity stages:
+
+| Level | Meaning |
+|-------|---------|
+| **Raw** | Just captured, unexamined |
+| **Developing** | Being explored, has potential |
+| **Refined** | Shaped, tested, ready for evaluation |
+| **Ready** | Decision made, ready to execute |
+| **Parked** | Not now, but worth keeping |
+| **Eliminated** | Killed, with documented reasoning |
+
+## Examples
+
+### Example 1: SaaS Product Ideation
+
+**Prompt:**
+```
+I want to brainstorm a developer tool for API documentation. The current tools
+feel either too enterprise-heavy or too basic. Help me find the opportunity.
+```
+
+**Session flow:**
+
+1. Claude asks session-start questions; user selects: new project, deep exploration, connected mode
+2. Claude identifies this as "Product/SaaS Ideation" and recommends Jobs-to-be-Done + Audience Reality Check
+3. Together they explore the problem space, Claude pushing back on assumptions: "You're assuming developers write the docs -- is that true?"
+4. Mid-session, Claude suggests SCAMPER to generate variations on the core concept
+5. A decision crystallizes; Claude logs it with reasoning
+6. Session ends with exit summary, overnight question, and v1 document
+
+### Example 2: Continuing a Book Brainstorm
+
+**Prompt:**
+```
+Continuing our brainstorm on the nonfiction book. Here's v3. [uploads file]
+I've been thinking about the overnight question and I think Chapter 4 needs to come first.
+```
+
+**Session flow:**
+
+1. Claude acknowledges continuation, reads v3, asks about session energy (user chooses quick progress)
+2. Claude notes: "This relates to what we discussed in Session 2 about narrative flow"
+3. They work through the chapter reordering, Claude asking hard questions about the logic
+4. Claude challenges the reasoning; user pushes back; both perspectives get logged
+5. Decision is made and captured; v4 is generated
+
+### Example 3: Quick Capture Mode
+
+**Prompt:**
+```
+Quick capture -- I'm about to go into a meeting but I just had an idea about
+a newsletter format that combines book summaries with my own frameworks.
+```
+
+**Session flow:**
+
+1. Claude enters quick capture mode
+2. Asks only 2-3 clarifying questions
+3. Creates minimal v1 document
+4. Notes: "Quick capture -- expand in future session"
+5. Gives user one overnight question to consider
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| **Claude isn't pushing back enough** | Explicitly ask: "Play devil's advocate here" or "What am I missing?" |
+| **Session feels unfocused** | Switch to quick progress mode and define a clear scope: "What decision do we need to make today?" |
+| **Ideas feel stale** | Request a divergent method: "Let's try Random Stimulus to break out of this rut" |
+| **Lost track of what was decided** | Request an index file update or synthesis document |
+| **Cross-project connections are distracting** | Switch to clean-slate mode for fresh perspective |
+| **Session running too long** | Claude should check in at natural breakpoints; if not, request a pause and exit summary |
+| **Continuing session but context seems off** | Ensure you're providing the latest version file, not an older one |
+
+## Related Files
+
+- **Source:** `/Users/robertguss/Projects/github/claude-skills/brainstorm/SKILL.md`
+- **Methods Reference:** `/Users/robertguss/Projects/github/claude-skills/brainstorm/references/methods-detailed.md`
+- **Quick Methods Guide:** `/Users/robertguss/Projects/github/claude-skills/brainstorm/references/methods-quick.md`
+- **Session Types:** `/Users/robertguss/Projects/github/claude-skills/brainstorm/references/session-types.md`
+- **Project Template:** `/Users/robertguss/Projects/github/claude-skills/brainstorm/assets/templates/project-template.md`
+- **Index Template:** `/Users/robertguss/Projects/github/claude-skills/brainstorm/assets/templates/index-template.md`

--- a/docs/skills/brainstorm/index.md
+++ b/docs/skills/brainstorm/index.md
@@ -8,7 +8,7 @@ The Brainstorm skill transforms Claude into a genuine intellectual partner for i
 
 At its core, Brainstorm operates on the principle that good ideas emerge through dialogue, not dictation. Claude will bring observations and suggestions proactively, push back on weak reasoning, surface connections to other work (when desired), and ask the hard questions you might avoid. The human always decides, but the reasoning gets logged -- creating a rich record of the thinking process, not just the conclusions.
 
-The skill solves the fundamental problem of multi-session creative work: maintaining continuity. Through versioned markdown documents, structured session logs, and idea maturity tracking, you can pick up exactly where you left off -- whether that was yesterday or three weeks ago.
+The skill solves the fundamental problem of multi-session creative work: maintaining continuity. Through versioned Markdown documents, structured session logs, and idea maturity tracking, you can pick up exactly where you left off -- whether that was yesterday or three weeks ago.
 
 ## Quick Start
 
@@ -24,14 +24,14 @@ The skill solves the fundamental problem of multi-session creative work: maintai
 ```markdown
 ## Skills
 
-- /path/to/brainstorm/SKILL.md
+When brainstorming, read and follow /path/to/claude-skills/brainstorm/SKILL.md.
 ```
 
 **For Claude.ai**, upload the packaged `.skill` file via Settings > Skills.
 
 **Sample prompt to begin:**
 
-```
+```text
 I want to brainstorm a new SaaS product idea. I've noticed that developer tools
 for API documentation are either too complex or too basic. Help me explore this space.
 ```
@@ -125,7 +125,7 @@ Every session concludes with three elements:
 
 **File structure:**
 
-```
+```text
 brainstorms/
   _parking-lot.md              # Cross-project idea capture
   project-name/
@@ -248,7 +248,7 @@ Ideas move through six maturity stages:
 ### Example 1: SaaS Product Ideation
 
 **Prompt:**
-```
+```text
 I want to brainstorm a developer tool for API documentation. The current tools
 feel either too enterprise-heavy or too basic. Help me find the opportunity.
 ```
@@ -265,7 +265,7 @@ feel either too enterprise-heavy or too basic. Help me find the opportunity.
 ### Example 2: Continuing a Book Brainstorm
 
 **Prompt:**
-```
+```text
 Continuing our brainstorm on the nonfiction book. Here's v3. [uploads file]
 I've been thinking about the overnight question and I think Chapter 4 needs to come first.
 ```
@@ -281,7 +281,7 @@ I've been thinking about the overnight question and I think Chapter 4 needs to c
 ### Example 3: Quick Capture Mode
 
 **Prompt:**
-```
+```text
 Quick capture -- I'm about to go into a meeting but I just had an idea about
 a newsletter format that combines book summaries with my own frameworks.
 ```
@@ -308,9 +308,9 @@ a newsletter format that combines book summaries with my own frameworks.
 
 ## Related Files
 
-- **Source:** `/Users/robertguss/Projects/github/claude-skills/brainstorm/SKILL.md`
-- **Methods Reference:** `/Users/robertguss/Projects/github/claude-skills/brainstorm/references/methods-detailed.md`
-- **Quick Methods Guide:** `/Users/robertguss/Projects/github/claude-skills/brainstorm/references/methods-quick.md`
-- **Session Types:** `/Users/robertguss/Projects/github/claude-skills/brainstorm/references/session-types.md`
-- **Project Template:** `/Users/robertguss/Projects/github/claude-skills/brainstorm/assets/templates/project-template.md`
-- **Index Template:** `/Users/robertguss/Projects/github/claude-skills/brainstorm/assets/templates/index-template.md`
+- **Source:** `brainstorm/SKILL.md`
+- **Methods Reference:** `brainstorm/references/methods-detailed.md`
+- **Quick Methods Guide:** `brainstorm/references/methods-quick.md`
+- **Session Types:** `brainstorm/references/session-types.md`
+- **Project Template:** `brainstorm/assets/templates/project-template.md`
+- **Index Template:** `brainstorm/assets/templates/index-template.md`

--- a/docs/skills/ebook-factory/ebook-concept-development.md
+++ b/docs/skills/ebook-factory/ebook-concept-development.md
@@ -1,0 +1,268 @@
+# Ebook Concept Development
+
+> Develop ebook ideas into structured concepts ready for architecture. Takes a single idea and develops it into a clear Ebook Concept Document with reader, transformation, promise, content source, scope/format, and key topics.
+
+---
+
+## Overview
+
+The Ebook Concept Development skill takes ONE ebook idea and develops it into a structured concept ready for architecture. Unlike generic brainstorming, this skill constantly applies ebook-specific pressure: format-fit calibration, value density thinking, and transformation sizing.
+
+This is genuine intellectual partnership—Claude contributes substance, offers observations, and pushes back on weak ideas with reasoning. Every element must earn its place in an ebook's concentrated solution.
+
+---
+
+## Quick Start
+
+### Prerequisites
+
+- An ebook idea from any source:
+  - Fresh concept
+  - Brainstorm document from [Ebook Discovery](ebook-discovery.md)
+  - Existing content to repurpose
+  - Section from a larger book to extract
+
+### Basic Usage
+
+=== "Claude Code"
+
+    ```markdown
+    When developing ebook concepts, read and follow /path/to/claude-skills/ebook-factory/ebook-concept-development/SKILL.md.
+    ```
+
+=== "Claude.ai"
+
+    Upload `ebook-concept-development.skill` to Settings → Skills.
+
+**Sample prompt:**
+```
+I have an ebook idea I want to develop. Here's what I'm thinking: [describe idea]
+```
+
+---
+
+## Features
+
+| Feature | Description |
+|---------|-------------|
+| **Ebook-Specific Pressure** | Format-fit calibration, value density, transformation sizing |
+| **Five Core Elements** | Reader, Transformation, Promise, Content Source, Scope & Format |
+| **Situational Elements** | Value Gap and Enemy surface when relevant |
+| **Living Document** | Updated at milestones, not constantly |
+| **Stress Testing** | Coherence and viability check before handoff |
+| **Multi-Session Support** | Pick up exactly where you left off |
+
+---
+
+## The Five Core Elements
+
+Every ebook concept needs these developed:
+
+| Element | Core Question | "Developed" Means |
+|---------|---------------|-------------------|
+| **Reader** | Who specifically is this for? | A specific person, not a category. Their situation, problem, what they've tried. |
+| **Transformation** | Where before → where after? | Concrete states. You can picture the person at each point. |
+| **Promise** | What does the reader get? | One compelling sentence. Specific, believable, would make someone pay. |
+| **Content Source** | What existing content feeds this? | Clear inventory: original, repurposed, or extracted from larger work. |
+| **Scope & Format** | What's the shape? | Word count range, format type, platform, what's explicitly OUT. |
+
+---
+
+## Situational Elements
+
+These surface naturally when signals appear—never forced:
+
+| Element | When It Applies | Signal Phrases |
+|---------|-----------------|----------------|
+| **Value Gap** | Creator-led ebooks (repurposed content) | "I have videos on this," "my newsletter covers this" |
+| **Enemy** | Argument-driven ebooks | "Most people think X but actually Y," "conventional wisdom is wrong" |
+
+---
+
+## Ebook-Specific Calibration
+
+What makes this different from generic brainstorming:
+
+### Format-Fit Calibration
+
+Is this genuinely ebook-sized?
+
+- **Too thin** = blog post
+- **Too thick** = full book
+- **Just right** = concentrated solution in 5,000-25,000 words
+
+### Value Density Thinking
+
+Ebooks are concentrated solutions. Every element must earn its place. If content could be cut without losing value, it should be.
+
+### Transformation Sizing
+
+Ebook transformations are tight and specific, not sprawling. "Go from confused about X to confidently doing Y" not "become a complete expert in everything."
+
+---
+
+## Workflow
+
+### Arriving with Material
+
+You might bring:
+
+- A single sentence idea
+- A rough paragraph
+- A brainstorm document from Ebook Discovery
+- Existing content to repurpose
+- A section from a larger book
+
+Claude reads the room—coming in hot with analysis for developed material, drawing out more for thin material.
+
+### First Response Pattern
+
+After receiving material, Claude provides:
+
+1. Summary of the core idea as understood
+2. What seems strongest or clearest
+3. What seems fuzzy or underdeveloped
+4. Initial observations or concerns (with reasoning)
+5. One focused question to start developing
+
+### During the Session
+
+**Collaboration behaviors:**
+
+- Proactive observations: "I notice the transformation has two stages—is this one ebook or two?"
+- Challenge with reasoning: "The scope feels ambitious because you're describing three distinct skill-building stages."
+- Surface connections: "Your reader and promise seem misaligned—reader is beginners but promise assumes they understand X."
+
+**Working the elements:**
+
+- Don't march through elements like a checklist
+- Follow natural conversation flow
+- Acknowledge when elements become developed
+- Circle back to fuzzy elements naturally
+
+### Readiness and Stress Test
+
+When elements feel developed, Claude offers a stress test:
+
+**Element quality:**
+- Reader specific enough for real decisions?
+- Transformation has clear before/after?
+- Promise compelling enough to pay for?
+- Scope genuinely ebook-sized?
+- Topics sufficient to deliver transformation?
+
+**Internal coherence:**
+- Does everything align? (Reader → Transformation → Promise → Topics)
+- Any contradictions?
+- Does format serve content and reader?
+
+**Viability concerns:**
+- Any red flags noticed during development?
+- Anything forced or uncertain?
+
+---
+
+## Inputs & Outputs
+
+### Inputs
+
+| Input | Description |
+|-------|-------------|
+| Ebook idea | Any form—sentence, paragraph, brainstorm document, existing content |
+| Working document | If continuing a previous session |
+
+### Outputs
+
+| Output | Description |
+|--------|-------------|
+| **Ebook Concept Document** | Living document with all elements, decisions, and reasoning |
+| **Readiness Verdict** | Clear when concept is ready for architecture |
+
+---
+
+## Readiness Criteria
+
+Ready for architecture when:
+
+- [ ] Reader can be described as a specific person
+- [ ] Transformation has clear before/after states
+- [ ] Promise is one compelling sentence
+- [ ] Scope is defined and genuinely ebook-sized
+- [ ] Key topics/concepts identified
+- [ ] Value Gap articulated (if creator-led)
+- [ ] Stress test passed
+
+---
+
+## Best Practices
+
+- **One question at a time** — Never overwhelm with multiple questions
+- **Reasoning with every pushback** — "This scope feels too big because..." not just "feels too big"
+- **Surface problems early** — Better to kill weak concept now than finish weak ebook
+- **Don't force situational elements** — Let Value Gap and Enemy emerge naturally
+- **Update document at milestones** — Not after every exchange
+
+---
+
+## Integration
+
+### Pipeline Position
+
+```mermaid
+flowchart LR
+    A[ebook-discovery] --> B[ebook-concept-development]
+    B --> C[ebook-architecture]
+```
+
+### Upstream Skills
+
+- **[Ebook Discovery](ebook-discovery.md)** — Provides brainstorm documents with candidate ideas
+
+### Downstream Skills
+
+- **Ebook Architecture** — Receives validated Ebook Concept Document
+
+---
+
+## References
+
+The skill loads these as needed:
+
+- `format-options.md` — Catalog of ebook formats (prose, workbook, etc.)
+- `element-examples.md` — Good/bad examples for each element
+- `failure-patterns.md` — Anti-patterns and warning signs
+
+---
+
+## Examples
+
+### Example 1: Developing from Discovery Output
+
+**Input:** Brainstorm document with 3 candidate ideas, user has selected one to develop.
+
+**Session flow:**
+1. Claude reads brainstorm, confirms which idea to develop
+2. Provides initial analysis of what's clear vs. fuzzy
+3. Focuses first question on reader specificity
+4. Works through elements naturally via conversation
+5. Runs stress test when elements feel developed
+6. Produces final Ebook Concept Document
+
+### Example 2: Repurposed Content
+
+**Input:** "I have a 12-video course on productivity. Want to extract an ebook."
+
+**Session flow:**
+1. Claude asks about course content structure
+2. Identifies Value Gap early (creator-led signal)
+3. Works to identify which portion = ebook vs. full course
+4. Calibrates scope to ebook format
+5. Develops transformation specific to extracted portion
+6. Stress tests coherence between source content and concept
+
+---
+
+## Related Skills
+
+- [Ebook Discovery](ebook-discovery.md) — Generate ebook ideas to feed this skill
+- [Brainstorm](../brainstorm/index.md) — General ideation that might produce ebook candidates

--- a/docs/skills/ebook-factory/ebook-concept-development.md
+++ b/docs/skills/ebook-factory/ebook-concept-development.md
@@ -226,11 +226,11 @@ flowchart LR
 
 ## References
 
-The skill loads these as needed:
+The skill loads these reference files as needed from the `ebook-factory/ebook-concept-development/references/` directory:
 
-- `format-options.md` — Catalog of ebook formats (prose, workbook, etc.)
-- `element-examples.md` — Good/bad examples for each element
-- `failure-patterns.md` — Anti-patterns and warning signs
+- Format options — Catalog of ebook formats (prose, workbook, etc.)
+- Element examples — Good/bad examples for each element
+- Failure patterns — Anti-patterns and warning signs
 
 ---
 

--- a/docs/skills/ebook-factory/ebook-discovery.md
+++ b/docs/skills/ebook-factory/ebook-discovery.md
@@ -1,0 +1,255 @@
+# Ebook Discovery
+
+> Surface ebook ideas you didn't know you had. Use when ready to discover what ebooks might be hiding in your content, expertise, or thinking.
+
+## Overview
+
+Ebook Discovery is the optional "upstream" skill that feeds into Concept Development. It's designed for divergent, generative exploration - answering "what's here?" rather than "is this right?"
+
+This skill serves two types of creators equally well: those with published content to mine (blog posts, videos, newsletters, podcasts) and those with unpublished expertise (tacit knowledge that feels obvious to you but valuable to others). Both paths are rich territory for ebook discovery.
+
+Claude operates as an active intellectual partner who contributes ideas proactively, not just a facilitator who asks questions. The skill emphasizes one question at a time, pushback with reasoning, and progressive disclosure of options rather than overwhelming menus.
+
+## Quick Start
+
+### Prerequisites
+- Clarity on whether you have published content to mine or unpublished expertise to extract
+- Willingness to explore and be challenged on viability
+- A file location for your Discovery Tracker document
+
+### Basic Usage
+
+1. **Invoke the skill** when you want to explore what ebooks might be hiding in your work
+2. **Answer the orientation question** about your content vs. expertise starting point
+3. **Share your intent** (income, authority, audience service, passion project)
+4. **Create the Discovery Tracker** document
+5. **Explore entry modes** with Claude's guidance
+
+## Features
+
+### 11 Entry Modes for Discovery
+
+The skill provides 11 distinct modes for uncovering ebook candidates, introduced progressively rather than as an overwhelming menu:
+
+**Content-Based Modes** (mine what you've published):
+| Mode | What It Finds |
+|------|---------------|
+| **Content Audit** | Patterns in blog posts, videos, newsletters, podcasts, teaching materials |
+| **Book Extraction** | Sections from larger book projects that could stand alone |
+| **Failed Project Resurrection** | Abandoned drafts and stalled projects (wrong format, not wrong idea?) |
+
+**Audience-Based Modes** (learn from your readers/viewers):
+| Mode | What It Finds |
+|------|---------------|
+| **Repeated Questions Analysis** | YouTube comments, email replies, questions after talks |
+
+**Knowledge-Based Modes** (surface what you know):
+| Mode | What It Finds |
+|------|---------------|
+| **Expertise Extraction** | Tacit knowledge that feels obvious to you but valuable to others |
+| **Contrarian Positions** | Views that push against mainstream thinking |
+| **Translation Bridges** | Things you explain between worlds you inhabit |
+| **Personal Systems** | Workflows, processes, disciplines you've developed |
+
+**Archive-Based Modes** (dig through your thinking):
+| Mode | What It Finds |
+|------|---------------|
+| **Zettelkasten Mining** | Clusters of connected notes revealing ebook-shaped ideas |
+| **Parking Lot Review** | Ideas parked during brainstorms, cross-project intersections |
+| **Deep Archive Mining** | Book marginalia, reading responses, long emails, "I wish this existed" frustrations |
+
+### Ebook-Specific Pressure Testing
+
+Throughout discovery, Claude applies constant format-fit calibration:
+- **Too thin?** Could be a blog post instead
+- **Too thick?** Should be a full book
+- **Ebook-shaped?** Natural scope of 10,000-25,000 words with focused transformation
+
+### Viability Assessment
+
+Candidates are evaluated against core viability criteria:
+- Clear idea (1-2 sentences)
+- Reader exists (specific person, not category)
+- Transformation defined (concrete before/after)
+- Author fit (unique perspective or experience)
+- Ebook fit (genuinely 10,000-25,000 words)
+
+## Workflow
+
+### First Session Flow
+
+```
+1. Orientation Question
+   "Do you have published content to mine, or unpublished expertise to extract?"
+
+2. Recommend Starting Mode
+   Claude suggests initial mode with reasoning
+
+3. Intent Question
+   "What's driving you to create ebooks?"
+
+4. Create Tracker
+   Establish the Discovery Tracker document
+
+5. Begin Exploration
+   Deep dive into selected mode
+```
+
+### During Exploration
+
+- **Deep dives, not quick scans** - Each mode warrants full exploration
+- **Active contribution** - Claude offers observations and candidate ideas
+- **Light triage** - Viability assessment as candidates surface
+- **Pattern recognition** - Cross-cutting themes often reveal strongest candidates
+- **Contextual transitions** - New modes introduced when relevant
+
+### Session End
+
+1. Update the tracker with current state
+2. Review candidates surfaced this session
+3. Note where to pick up next
+4. Identify candidates ready for Concept Development
+
+### Returning Sessions
+
+When returning with an existing tracker:
+1. Claude reads tracker to orient
+2. Status summary provided (modes explored, candidates, where you left off)
+3. Focus direction requested
+4. Skip orientation if context is clear
+
+## Inputs & Outputs
+
+### Inputs
+
+| Input | Description |
+|-------|-------------|
+| **Content inventory** | Blog posts, videos, newsletters, podcasts, teaching materials |
+| **Expertise areas** | Professional skills, hard-won knowledge, unique perspectives |
+| **Intent** | Income, authority, audience service, lead generation, passion |
+| **Existing material** | Drafts, notes, Zettelkasten, parked ideas |
+
+### Outputs
+
+**Discovery Tracker** containing:
+- User profile (content inventory, expertise areas, intent)
+- Exploration log (which modes explored, how deeply)
+- Candidates with viability ratings and reasoning
+- Patterns and insights across candidates
+- Session notes for multi-session continuity
+
+**Handoff Summary** for selected candidate:
+- Core idea (1-2 sentences)
+- Source (which mode, what material)
+- Ebook-shaped assessment
+- Viability notes with reasoning
+- Known concerns
+
+## Best Practices
+
+### Do
+- **Start with your strongest path** - Content creators start with Content Audit, expertise holders with Expertise Extraction
+- **Go deep before going wide** - Explore one mode thoroughly before switching
+- **Trust Claude's pattern recognition** - Cross-cutting themes often reveal the best candidates
+- **Note validation signals** - High engagement, repeat questions, direct requests
+- **Be honest about energy** - Low energy = low completion probability
+
+### Don't
+- **Force all 11 modes** - Use what's relevant to your situation
+- **Rush viability assessment** - Light triage during exploration, deeper assessment at transitions
+- **Ignore "too thin" or "too thick" signals** - Format fit matters
+- **Skip the intent question** - It shapes which candidates to prioritize
+- **Treat this as brainstorming** - It's structured discovery with ebook-specific pressure
+
+### Red Flags
+
+| Warning Sign | What It Means |
+|--------------|---------------|
+| Can't state idea in 1-2 sentences | Not yet clear enough |
+| "Everyone" as the reader | No specific audience |
+| Vague transformation | Just information, not behavior change |
+| "Anyone could write this" | No unique author fit |
+| Stretching to fill pages | Too thin for ebook |
+| Can't cut without losing essentials | Too thick for ebook |
+
+## Integration
+
+### Pipeline Position
+
+Ebook Discovery is **Skill 0** - the optional upstream skill that feeds into Concept Development. Users with existing ideas can skip directly to Concept Development.
+
+```
+[Ebook Discovery] --> [Ebook Concept Development] --> [Ebook Architecture] --> ...
+     (optional)
+```
+
+### Upstream Skills
+None - this is the entry point to the pipeline.
+
+### Downstream Skills
+- **[Ebook Concept Development](./ebook-concept-development.md)** - Takes selected candidate and develops it into a structured concept with defined reader, transformation, promise, content source, and scope.
+
+### Handoff Criteria
+
+A candidate is ready for Concept Development when:
+- Core idea stated in 1-2 sentences
+- Source identified (which mode, what material)
+- Appears ebook-shaped (not too thin, not too thick)
+- Viability notes captured with reasoning
+- Known concerns documented
+- User has decided to pursue it
+
+## Examples
+
+### Example 1: Content Creator with YouTube Channel
+
+**Situation:** YouTuber with 50K subscribers and 200+ videos on productivity topics.
+
+**Discovery path:** Content Audit reveals a cluster of 8 videos on "morning routines" with unusually high engagement. Comments repeatedly ask for more detail on the "energy audit" concept mentioned in one video.
+
+**Outcome:** Strong candidate identified - an ebook deep-diving the energy audit framework, expanding what couldn't fit in video format.
+
+### Example 2: Professional with Unpublished Expertise
+
+**Situation:** Engineering manager who's never published content but keeps getting asked how they handle difficult performance conversations.
+
+**Discovery path:** Expertise Extraction surfaces the specific framework they've developed over 10 years. Repeated Questions Analysis (from 1-on-1s and conference chats) validates demand.
+
+**Outcome:** Candidate for an ebook on performance conversation frameworks for engineering managers.
+
+### Example 3: Writer with Abandoned Projects
+
+**Situation:** Writer with three abandoned book projects, each stalled around 15,000 words.
+
+**Discovery path:** Failed Project Resurrection reveals all three projects stalled because they were "too big." Each could be ebook-sized if scope was narrowed. One project on "writing habits" still generates enthusiasm.
+
+**Outcome:** Resurrection of the writing habits project as an ebook with tighter scope.
+
+### Example 4: Multi-Domain Expert
+
+**Situation:** UX designer who also does improv comedy and has been explaining design thinking to comedy people and performance skills to designers.
+
+**Discovery path:** Translation Bridges surfaces unique insights from bridging these worlds. Personal Systems reveals a specific warm-up routine adapted from improv for design brainstorming sessions.
+
+**Outcome:** Ebook on applying improv principles to design workshops - unique positioning at the intersection.
+
+## Reference Files
+
+The skill includes these reference documents loaded as needed:
+
+| Reference | Purpose |
+|-----------|---------|
+| `entry-modes-guide.md` | Deep guidance for all 11 discovery modes |
+| `expertise-extraction-guide.md` | Dedicated support for the harder unpublished expertise path |
+| `candidate-assessment.md` | Viability criteria, examples, validation signals |
+| `discovery-anti-patterns.md` | Common problems and interventions |
+| `prioritization-guide.md` | Choosing among candidates, series thinking |
+| `content-transformation.md` | How different content types become ebooks |
+| `discovery-questions.md` | Powerful question toolkit |
+
+## Templates
+
+| Template | Purpose |
+|----------|---------|
+| `discovery-tracker-template.md` | Living document for tracking discovery progress |
+| `handoff-summary-template.md` | Clean handoff to Concept Development |

--- a/docs/skills/ebook-factory/index.md
+++ b/docs/skills/ebook-factory/index.md
@@ -1,0 +1,167 @@
+# Ebook Factory
+
+> A streamlined pipeline for creating high-quality ebooks - concentrated solutions optimized for speed-to-value.
+
+## Overview
+
+The Ebook Factory is a suite of Claude skills designed specifically for ebook creation. Unlike the Book Factory (designed for 50,000-80,000 word nonfiction books), this pipeline is right-sized for 10,000-25,000 word ebooks that can be completed faster with lighter process overhead.
+
+The core philosophy: **Ebooks are not compressed books - they are a distinct format optimized for speed-to-value.** The constraint of being shorter makes ebooks harder to write well, not easier. Every sentence must earn its place. The reader who buys a short read values their time and expects density without filler.
+
+## Pipeline Overview
+
+```mermaid
+flowchart TD
+    subgraph discovery["SKILL 0: Discovery (Optional)"]
+        ED[ebook-discovery]
+    end
+
+    subgraph concept["SKILL 1: Concept Development"]
+        ECD[ebook-concept-development]
+    end
+
+    subgraph architecture["SKILL 2: Architecture"]
+        EA[ebook-architect]
+    end
+
+    subgraph outlining["SKILL 3: Chapter Outlining"]
+        CO[chapter-outliner]
+    end
+
+    subgraph research["SKILL 4: Research (Optional)"]
+        ER[ebook-research]
+    end
+
+    subgraph drafting["SKILL 5: Drafting"]
+        EDR[ebook-drafter]
+    end
+
+    subgraph editing["SKILL 6: Editing"]
+        EE[ebook-editor]
+    end
+
+    subgraph publish["Ready to Publish"]
+        DONE[Final Manuscript]
+    end
+
+    ED -->|Discovery Tracker| ECD
+    ECD -->|Concept Document| EA
+    EA -->|Architecture Document| CO
+    CO -->|Chapter Outlines| ER
+    ER -->|Research Notes| EDR
+    CO -->|Skip if not needed| EDR
+    EDR -->|First Draft| EE
+    EE --> DONE
+```
+
+## Pipeline Characteristics
+
+| Characteristic | Description |
+|----------------|-------------|
+| **Linear but flexible** | Skills flow in sequence, but some may be compressed or skipped |
+| **Single-session default** | Each skill designed to complete in one focused session |
+| **Chapter-by-chapter option** | Outlining and drafting can work incrementally with review points |
+| **Research is conditional** | Not every ebook needs dedicated research |
+| **Discovery is optional** | Users with existing ideas skip straight to Concept Development |
+
+## Ebooks vs. Full Books
+
+| Aspect | Ebook | Full Book |
+|--------|-------|-----------|
+| **Word Count** | 10,000-25,000 | 50,000-80,000 |
+| **Timeline** | Weeks | Months |
+| **Transformation** | Single, focused | Multi-stage, comprehensive |
+| **Reading Sessions** | 1-3 sessions | Multiple sessions |
+| **Chapter Count** | 4-8 chapters | 12-20+ chapters |
+| **Process Weight** | Lighter documentation | Thorough documentation |
+| **AI Role** | Primary drafter | Coach/collaborator |
+
+## When to Use This Pipeline
+
+**Use Ebook Factory when:**
+- Your transformation is tight and specific
+- The content naturally fits 10,000-25,000 words
+- You want to ship quickly
+- You're repurposing existing content (videos, blog posts, newsletters)
+- You're testing audience interest before a larger book
+- The reader's problem can be solved in 1-3 reading sessions
+
+**Use Book Factory when:**
+- Your transformation requires multiple sequential stages
+- The topic demands comprehensive treatment
+- You need extensive research and evidence
+- The content naturally expands to 50,000+ words
+- You're building a definitive resource
+
+## Design Principles
+
+### 1. Single Document Per Skill
+Each skill produces one working document rather than multiple files. Simpler to track, easier to pass forward.
+
+### 2. Embedded References
+Essential guidance is embedded in skills rather than split across many reference files. References are limited to catalogs and templates that would bloat the main skill.
+
+### 3. Single-Session Default
+Skills are designed to complete in one focused session. This creates momentum and prevents projects from stalling.
+
+### 4. Reader-First, Always
+Every decision - structural, stylistic, content - is evaluated from the reader's perspective. Will this help the reader understand? Keep them engaged? Move them toward transformation?
+
+### 5. Claude as True Collaborator
+Claude is not an assistant waiting for instructions. Claude contributes ideas proactively, pushes back on weak thinking, challenges assumptions, and brings genuine expertise.
+
+### 6. Brutal Honesty Over Ego Protection
+The skills exist to surface problems early when they're cheap to fix. Better to kill a weak idea now than finish a weak ebook later.
+
+### 7. Quality Through Constraint
+Brevity is the discipline. The constraint of being shorter forces higher quality per page.
+
+## Skills in This Pipeline
+
+| Skill | Status | Purpose |
+|-------|--------|---------|
+| [ebook-discovery](./ebook-discovery.md) | Built | Surface ebook ideas you didn't know you had |
+| [ebook-concept-development](./ebook-concept-development.md) | Built | Develop ideas into structured concepts |
+| ebook-architect | Planned | Design the reader's journey and chapter structure |
+| chapter-outliner | Planned | Create beat-level outlines for each chapter |
+| ebook-research | Planned | Fill research gaps identified during planning |
+| ebook-drafter | Planned | Produce the complete first draft |
+| ebook-editor | Planned | Refine draft into polished final manuscript |
+
+## Handoffs Between Skills
+
+Clear handoffs ensure continuity between skills:
+
+### Discovery to Concept Development
+- Discovery Tracker with evaluated candidates
+- Candidate handoff summary for chosen idea
+- User profile (intent, content inventory, expertise)
+- Viability assessment with reasoning
+
+### Concept Development to Architecture
+- Ebook Concept Document with all elements developed
+- Scope boundaries defined
+- Platform direction
+- Open questions identified
+
+### Architecture to Outlining
+- Ebook Architecture Document with full chapter sequence
+- Each chapter's job, entry/exit states, word budget
+- Research gaps and visual needs identified
+
+### Outlining to Drafting
+- Complete chapter outlines with beats
+- Word budgets per beat
+- Subheading suggestions
+- Opening/closing approaches
+
+### Drafting to Editing
+- Complete first draft
+- Inline flags and placeholders
+- Draft self-assessment
+- Voice parameters used
+
+## Related Resources
+
+- [Non-Fiction Book Factory](../non-fiction-book-factory/index.md) - For full-length books
+- [Pipelines Concept](../../concepts/pipelines.md) - Understanding skill pipelines

--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -1,0 +1,104 @@
+# Skills Catalog
+
+A complete collection of skills organized by category.
+
+---
+
+## Standalone Skills
+
+| Skill | Description |
+|-------|-------------|
+| [Brainstorm](brainstorm/index.md) | Collaborative multi-session brainstorming with versioned documents, 25+ thinking methods, and decision tracking |
+
+---
+
+## Skill Pipelines
+
+Pipelines are collections of skills designed to work together in sequence, with structured handoffs between stages.
+
+### Non-Fiction Book Factory
+
+A complete pipeline for developing nonfiction books from initial idea to chapter-level architecture.
+
+```mermaid
+flowchart LR
+    A[book-ideation] --> B[book-idea-validator]
+    B --> C[book-market-research]
+    C --> D[book-architect]
+    D --> E[book-research-assistant]
+    E --> F[chapter-architect]
+```
+
+| Skill | Description |
+|-------|-------------|
+| [Book Ideation](non-fiction-book-factory/book-ideation.md) | Develop raw ideas into structured Book Concept Documents with 8 core elements |
+| [Book Idea Validator](non-fiction-book-factory/book-idea-validator.md) | Stress-test concepts against existing research (Go/Revise/Kill recommendation) |
+| [Book Market Research](non-fiction-book-factory/book-market-research.md) | Assess commercial viability for Amazon KDP self-publishing |
+| [Book Architect](non-fiction-book-factory/book-architect.md) | Design structural and emotional architecture for drafting |
+| [Book Research Assistant](non-fiction-book-factory/book-research-assistant.md) | Plan, orchestrate, and validate deep research before outlining |
+| [Chapter Architect](non-fiction-book-factory/chapter-architect.md) | Plan individual chapters at beat-level granularity for drafting |
+
+[:octicons-arrow-right-24: Full Book Factory Documentation](non-fiction-book-factory/index.md)
+
+---
+
+### Ebook Factory
+
+A streamlined pipeline for creating ebooks—shorter, concentrated solutions optimized for speed-to-value.
+
+```mermaid
+flowchart LR
+    A[ebook-discovery] --> B[ebook-concept-development]
+```
+
+| Skill | Description |
+|-------|-------------|
+| [Ebook Discovery](ebook-factory/ebook-discovery.md) | Surface ebook ideas from content, expertise, and archives (11 entry modes) |
+| [Ebook Concept Development](ebook-factory/ebook-concept-development.md) | Develop ideas into structured concepts ready for architecture |
+
+[:octicons-arrow-right-24: Full Ebook Factory Documentation](ebook-factory/index.md)
+
+---
+
+### Writing
+
+A pipeline for capturing and replicating a writer's authentic voice.
+
+```mermaid
+flowchart LR
+    A[writing-dna-discovery] --> B[ghost-writer]
+```
+
+| Skill | Description |
+|-------|-------------|
+| [Writing DNA Discovery](writing/writing-dna-discovery.md) | Capture voice patterns through collaborative interview and sample analysis |
+| [Ghost Writer](writing/ghost-writer.md) | Produce first drafts at ~80% voice accuracy using Voice DNA Documents |
+
+[:octicons-arrow-right-24: Full Writing Documentation](writing/index.md)
+
+---
+
+## Skill Comparison
+
+| Feature | Brainstorm | Book Factory | Ebook Factory | Writing |
+|---------|------------|--------------|---------------|---------|
+| Multi-session | Yes | Yes | Yes | Yes |
+| Pipeline | No | 6 skills | 2 skills | 2 skills |
+| Versioned docs | Yes | Yes | Yes | Yes |
+| Templates | Yes | Yes | Yes | Yes |
+
+---
+
+## Choosing the Right Skill
+
+**Need to explore ideas?**
+→ Start with [Brainstorm](brainstorm/index.md)
+
+**Writing a comprehensive nonfiction book?**
+→ Use the [Non-Fiction Book Factory](non-fiction-book-factory/index.md) pipeline
+
+**Creating a focused, shorter ebook?**
+→ Use the [Ebook Factory](ebook-factory/index.md) pipeline
+
+**Need to capture or replicate a writing voice?**
+→ Use the [Writing](writing/index.md) pipeline

--- a/docs/skills/non-fiction-book-factory/book-architect.md
+++ b/docs/skills/non-fiction-book-factory/book-architect.md
@@ -1,0 +1,232 @@
+# Book Architect
+
+> Design the structural and emotional architecture for nonfiction books. Creates the comprehensive blueprint before drafting—every structural decision serves the reader's transformation journey.
+
+---
+
+## Overview
+
+The Book Architect skill designs the reader's journey and creates a comprehensive structural blueprint for nonfiction books. The guiding principle: the question is never "how do I organize my ideas?" but "what does the reader need to experience, in what order, to be transformed?"
+
+This skill creates **dual architecture**—both structural architecture (what goes where) and emotional architecture (what the reader feels and experiences). Chapters aren't containers for content; they're journeys that transform readers from an entry state to an exit state.
+
+Claude operates as an expert collaborator: direct about architectural problems, pushing back on weak structure, but warm toward the author—ruthless toward the architecture, supportive of the person.
+
+---
+
+## Quick Start
+
+### Prerequisites
+
+- Book Concept Document (required)
+- Validation Report (recommended)
+- Market Research Report (recommended)
+
+### Basic Usage
+
+=== "Claude Code"
+
+    ```markdown
+    When architecting a book, read and follow /path/to/claude-skills/non-fiction-book-factory/book-architect/SKILL.md.
+    ```
+
+=== "Claude.ai"
+
+    Upload `book-architect.skill` to Settings → Skills.
+
+**Sample prompt:**
+```
+I'm ready to architect my book. Here are my upstream documents:
+- Book Concept Document: [paste]
+- Validation Report: [paste]
+```
+
+---
+
+## Features
+
+| Feature | Description |
+|---------|-------------|
+| **Dual Architecture** | Structural (what goes where) + Emotional (what reader feels) |
+| **Reader-First Design** | Every decision justified by reader experience |
+| **Intake Assessment** | Synthesizes upstream documents, checks readiness |
+| **Structural Frameworks** | Catalog of proven structures with guidance |
+| **Hook Chain Design** | Each chapter's exit pulls into next chapter's entry |
+| **Pacing Strategy** | Intentional rhythm—no accidental slog zones |
+| **Research Gap Identification** | Surfaces what needs filling before drafting |
+
+---
+
+## Core Philosophy
+
+1. **Reader-first architecture** — Every decision is justified by reader experience, not author convenience
+
+2. **Chapters are journeys, not containers** — Each transforms the reader from entry state to exit state
+
+3. **Diagnose before prescribing** — Assess what THIS book needs rather than applying a formula
+
+4. **Expert with warmth** — Direct about problems, supportive of the person
+
+---
+
+## Workflow
+
+### Intake Process
+
+Claude reads all provided documents and produces:
+
+1. **Synthesis Statement** — "Here's what I understand this book to be..."
+2. **Readiness Verdict** — Green / Yellow / Red
+3. **Structural Intuitions** — Initial hunches (not decisions—starting points)
+4. **Concerns & Questions** — Issues to address
+5. **The Burning Question** — Single most important thing to resolve
+6. **Proposed Work Plan** — Sessions needed, sequence of work
+
+### Readiness Signals
+
+**Green (ready to proceed):**
+- Thesis implies structure
+- Transformation has verbs (reader will START doing X, STOP doing Y)
+- Key concepts have relationships
+- Enemy is specific enough to create drama
+
+**Red (needs upstream work):**
+- Multiple books hiding as one
+- Unresolved validation concerns
+- Market positioning contradicts concept
+- Cannot articulate book in one clear paragraph
+
+### Building Architecture
+
+**Book-Level:**
+- Refine thesis and promise statement
+- Map transformation arc (stages reader moves through)
+- Select structural framework
+- Identify through-lines (themes woven throughout)
+- Map objections and resistance points
+- Assess proof burdens
+- Design pacing strategy
+
+**Chapter-Level:**
+- Work section by section
+- Define all blueprint elements for each chapter
+- Ensure hook chain flows
+- Watch for pacing problems
+- Flag research gaps as they emerge
+
+---
+
+## Inputs & Outputs
+
+### Inputs
+
+| Input | Required | Source |
+|-------|----------|--------|
+| Book Concept Document | Yes | book-ideation |
+| Validation Report | Recommended | book-idea-validator |
+| Market Research Report | Recommended | book-market-research |
+| Existing notes/outline | Optional | Author |
+
+### Outputs
+
+| Document | Description |
+|----------|-------------|
+| **Master Architecture Document** | Book identity, reader profile, transformation arc, framework rationale, section overview, through-lines, objection map, proof burden map, pacing strategy |
+| **Section Blueprint Documents** | One per section with detailed chapter blueprints |
+| **Research Gaps Document** | Prioritized gaps with ready-to-use research prompts |
+| **Progress Tracker** | Session continuity and status |
+| **Decision Log** | Architectural choices with reasoning |
+
+---
+
+## Chapter Blueprint Elements
+
+Each chapter blueprint includes:
+
+- Chapter number, title, type, one-line description
+- Chapter weight (Heavy/Medium/Light)
+- Incoming hook, outgoing hook
+- Reader emotional arc (starts/ends)
+- Key insight (the ONE thing)
+- Purpose (chapter's job)
+- Content outline
+- Through-line moments
+- Structural connections
+- What NOT to include
+- Proof burden notes
+- Resistance points
+- Research gaps
+
+---
+
+## Readiness Criteria
+
+Architecture is complete when:
+
+1. Master Architecture Document is finalized
+2. All Section Blueprints complete with every field filled
+3. Hook chain flows end-to-end
+4. Pacing shows intentional rhythm
+5. Every chapter has a distinct key insight
+6. All P1 research gaps documented with prompts
+7. Stress test passes
+8. Author confirms this is the book they want to write
+
+---
+
+## Best Practices
+
+- **Provide all upstream documents** — Better input = better architecture
+- **Trust the intake process** — Let Claude identify readiness issues
+- **Accept pushback on structure** — That's where value lives
+- **Don't rush chapters** — Each blueprint deserves full attention
+- **Use the decision log** — Future you will appreciate the reasoning
+
+---
+
+## Integration
+
+### Pipeline Position
+
+```mermaid
+flowchart LR
+    A[book-ideation] --> B[book-idea-validator]
+    B --> C[book-market-research]
+    C --> D[book-architect]
+    D --> E[book-research-assistant]
+    E --> F[chapter-architect]
+```
+
+### Upstream Skills
+
+- **book-ideation** — Provides Book Concept Document
+- **book-idea-validator** — Provides Validation Report
+- **book-market-research** — Provides Market Research Report
+
+### Downstream Skills
+
+- **book-research-assistant** — Receives Research Gaps Document
+- **chapter-architect** — Receives Section Blueprints
+
+---
+
+## References
+
+The skill loads these as needed:
+
+- `structural-frameworks.md` — Catalog of proven structures
+- `reader-resistance.md` — Types of objections and strategies
+- `pacing-cognitive-load.md` — Chapter weight and rhythm
+- `chapter-architecture.md` — Entry/exit states, hooks
+- `proof-burden-mapping.md` — What evidence claims need
+- `common-problems.md` — Architectural antipatterns
+
+---
+
+## Related Skills
+
+- [Book Ideation](book-ideation.md) — Creates the concept document
+- [Book Idea Validator](book-idea-validator.md) — Validates intellectual merit
+- [Book Market Research](book-market-research.md) — Validates commercial viability
+- [Book Research Assistant](book-research-assistant.md) — Fills research gaps
+- [Chapter Architect](chapter-architect.md) — Beat-level chapter planning

--- a/docs/skills/non-fiction-book-factory/book-idea-validator.md
+++ b/docs/skills/non-fiction-book-factory/book-idea-validator.md
@@ -1,0 +1,221 @@
+# Book Idea Validator
+
+> Stress-test book concepts against existing research before committing to architecture. Produces a Validation Report with Go/Revise/Kill recommendation. The goal is intellectual honesty, not ego validation.
+
+---
+
+## Overview
+
+The Book Idea Validator stress-tests the core ideas from your Book Concept Document against existing research, surfacing weaknesses early—when they're cheap to fix or when killing the project saves months of wasted effort.
+
+This skill operates on a fundamental principle: **better to kill a weak idea now than to finish a weak book later.** Claude functions as an intellectual partner who brings genuine contributions, pushes back on problems, and remains brutally honest about what works and what doesn't.
+
+The validation uses a two-layer research model: Claude performs landscape scans to map territory, then provides targeted prompts for deep research that you execute independently.
+
+---
+
+## Quick Start
+
+### Prerequisites
+
+- Completed [Book Concept Document](book-ideation.md) with all 8 core elements
+- Book Ideation skill outputs ready for validation
+
+### Basic Usage
+
+=== "Claude Code"
+
+    ```markdown
+    When validating book ideas, read and follow /path/to/claude-skills/non-fiction-book-factory/book-idea-validator/SKILL.md.
+    ```
+
+=== "Claude.ai"
+
+    Upload `book-idea-validator.skill` to Settings → Skills.
+
+**Sample prompt:**
+```
+I have a Book Concept Document ready for validation. Here it is: [paste document]
+```
+
+---
+
+## Features
+
+| Feature | Description |
+|---------|-------------|
+| **Two-Layer Research** | Landscape scan (Claude) + Deep research (user-executed with Claude-provided prompts) |
+| **Claim Extraction** | Systematically identifies all claims requiring validation |
+| **Competitor Analysis** | Maps the intellectual territory and identifies gaps |
+| **Kill Signal Detection** | Flags serious concerns that could sink the book |
+| **Green Light Identification** | Surfaces strengths that make the concept viable |
+| **Go/Revise/Kill Verdict** | Clear recommendation with reasoning |
+
+---
+
+## Workflow
+
+### Phase 1: Claim Extraction & Brainstorming
+
+1. Extract claims from Book Concept Document
+2. Present for confirmation
+3. Brainstorm additional claims together (Claude contributes proactively)
+4. Consolidate into categorized Master Claim List
+
+### Phase 2: Landscape Scan
+
+Claude searches each claim area and reports:
+
+- Key voices in the space
+- Existing coverage
+- Obvious gaps
+- Territory map
+
+### Phase 3: Deep Research Flagging
+
+For claims needing deeper investigation, Claude provides:
+
+1. **The claim** — Which specific claim needs investigation
+2. **Why it needs deep research** — What landscape scan couldn't answer
+3. **What we're hoping to learn** — The specific question
+4. **Suggested prompt** — Ready to paste into Claude/Gemini
+5. **Suggested sources** — Databases, books, or experts to consult
+
+### Phase 4: Deep Research Analysis
+
+- You return with findings from external research
+- Claude analyzes and synthesizes
+- May flag additional research needs
+
+### Phase 5: Validation Report
+
+- Synthesize all findings
+- Assess each claim: Strong / Needs Work / Weak
+- Identify kill signals and green lights
+- Deliver Go / Revise / Kill recommendation
+
+---
+
+## Inputs & Outputs
+
+### Inputs
+
+| Input | Required | Source |
+|-------|----------|--------|
+| Book Concept Document | Yes | book-ideation |
+| 8 core elements complete | Yes | Prerequisite check |
+
+### Outputs
+
+| Document | Purpose |
+|----------|---------|
+| Master Claim List | Categorized list of all claims to validate |
+| Landscape Scan Notes | Findings by claim: key sources, territory, gaps |
+| Deep Research Log | Prompts given, reasoning, findings returned |
+| Competitor Analysis | Books in adjacent territory, differentiation |
+| Decision Log | Why key choices were made |
+| Validation Report | Final synthesis with Go/Revise/Kill |
+
+---
+
+## Optional Documents
+
+Claude recommends these based on book type:
+
+**For Persuasive Books:**
+- Reader Resistance Map
+- Counterargument Registry
+- Claim Dependencies
+
+**For Research-Heavy Books:**
+- Quotes and Sources Bank
+- Personal Reading Queue
+
+**For How-To Books:**
+- Method Comparison Matrix
+- Common Mistakes Registry
+
+---
+
+## Kill Signals vs. Green Lights
+
+### Kill Signals (Serious Concerns)
+
+| Signal | Meaning |
+|--------|---------|
+| Already Said Better | Major recent book makes same argument more credibly |
+| Factually Problematic | Core claims contradict established evidence |
+| No Standing | Author lacks credibility for these claims |
+| Straw Man Enemy | "Enemy" is a caricature no one holds |
+| Moving Target | Thesis keeps shifting |
+| Solution Without Problem | No real reader has this problem |
+
+### Green Lights (Strengths)
+
+| Signal | Meaning |
+|--------|---------|
+| Genuine Novelty | Perspective hasn't been articulated this way |
+| Timely | Current events make this relevant |
+| Underserved Reader | Target reader isn't well-served by existing books |
+| Strong Evidence Base | Claims are well-supported |
+| Credible Author | Experience/expertise matches claims |
+| Clear Enemy | Argues against something specific and real |
+
+---
+
+## Claim Assessment Levels
+
+| Level | Meaning | Action |
+|-------|---------|--------|
+| **Strong** | Well-supported, defensible, author has credibility | Proceed with confidence |
+| **Needs Work** | Promising but gaps exist | Strengthen before architecture |
+| **Weak** | Significant problems | Major revision or consider cutting |
+
+---
+
+## Best Practices
+
+- **Provide complete concept document** — Missing elements get sent back to ideation
+- **Be open to hard truths** — The value is in honest assessment
+- **Do the deep research** — Claude provides prompts; you gather the evidence
+- **Document decisions** — The reasoning matters for future reference
+
+---
+
+## Integration
+
+### Pipeline Position
+
+```mermaid
+flowchart LR
+    A[book-ideation] --> B[book-idea-validator]
+    B --> C[book-market-research]
+    B --> D[book-architect]
+```
+
+### Upstream Skills
+
+- **book-ideation** — Provides the Book Concept Document
+
+### Downstream Skills
+
+- **book-market-research** — Receives Validation Report + Competitor Analysis
+- **book-architect** — Receives all core and optional documents
+
+---
+
+## Scope Boundaries
+
+This skill validates **intellectual merit**, not:
+
+- Commercial viability (that's [market-research](book-market-research.md))
+- Structural decisions (that's [book-architect](book-architect.md))
+- Writing quality (that's the editing pipeline)
+
+---
+
+## Related Skills
+
+- [Book Ideation](book-ideation.md) — Create the concept document this skill validates
+- [Book Market Research](book-market-research.md) — Commercial viability assessment
+- [Book Architect](book-architect.md) — Next step after validation passes

--- a/docs/skills/non-fiction-book-factory/book-idea-validator.md
+++ b/docs/skills/non-fiction-book-factory/book-idea-validator.md
@@ -25,16 +25,18 @@ The validation uses a two-layer research model: Claude performs landscape scans 
 
 === "Claude Code"
 
+    Add to your project's `CLAUDE.md`:
+
     ```markdown
     When validating book ideas, read and follow /path/to/claude-skills/non-fiction-book-factory/book-idea-validator/SKILL.md.
     ```
 
 === "Claude.ai"
 
-    Upload `book-idea-validator.skill` to Settings → Skills.
+    Upload the packaged `.skill` file via Settings → Skills (build with `python build.py book-idea-validator`).
 
 **Sample prompt:**
-```
+```text
 I have a Book Concept Document ready for validation. Here it is: [paste document]
 ```
 
@@ -190,7 +192,7 @@ Claude recommends these based on book type:
 flowchart LR
     A[book-ideation] --> B[book-idea-validator]
     B --> C[book-market-research]
-    B --> D[book-architect]
+    C --> D[book-architect]
 ```
 
 ### Upstream Skills

--- a/docs/skills/non-fiction-book-factory/book-ideation.md
+++ b/docs/skills/non-fiction-book-factory/book-ideation.md
@@ -1,0 +1,218 @@
+# Book Ideation
+
+> Develop raw book ideas into structured nonfiction book concepts. Use when the user wants to develop a book idea, has brainstorm documents to refine into a book concept, wants to articulate a book's thesis/promise/reader/transformation, or needs to prepare a book concept for validation and market research.
+
+## Overview
+
+Book Ideation transforms raw ideas into structured nonfiction book concepts through guided multi-session development. It sits between generic brainstorming and book architecture, refining raw material into a concept that can be validated, market-tested, and architected.
+
+The goal is not a book outline. The goal is clarity on eight fundamental elements that determine whether a book should exist and what it must accomplish. Every decision serves the reader--the question is never "what do I want to say?" but "what transformation does the reader need, and how can this book deliver it?"
+
+This skill bridges the gap between having an idea and having a book. It forces the hard questions early, when pivoting is cheap and easy.
+
+## Quick Start
+
+### Prerequisites
+
+No upstream skills are required. Book Ideation is the entry point for the Non-Fiction Book Factory pipeline.
+
+**Accepted inputs:**
+- Raw idea (one sentence or paragraph)
+- Brainstorm document from the `brainstorm` skill
+- Zettelkasten notes or research collection
+- Existing partial concept needing refinement
+- "Shower thought" worth exploring
+
+### Basic Usage
+
+**Starting a new concept:**
+```
+I have a book idea I want to develop. Here's my raw concept:
+
+[Your idea here - can be as rough as a single sentence]
+```
+
+**Continuing a previous session:**
+```
+I'd like to continue developing my book concept. Here's my latest
+Book Concept Document:
+
+[Paste your document]
+```
+
+## Features
+
+- **Multi-session development** with versioned documents (v1, v2, v3)
+- **Eight-element framework** for comprehensive concept clarity
+- **Quick Capture Mode** for rapid idea preservation
+- **Readiness criteria** to know when you're ready for validation
+- **Collaboration behaviors** that surface insights and challenge weakness
+- **Structural frameworks reference** for previewing potential book shapes
+
+## Workflow
+
+### Session Flow
+
+Each session follows this pattern:
+
+1. **New or continuing?** - Establish context and gather current documents
+2. **What do we have?** - Review raw material and identify gaps
+3. **Session goal** - Decide which elements to develop
+4. **Collaborative development** - Work through elements via conversation
+5. **Session wrap-up** - Document progress, create next version
+
+### The Eight Elements
+
+Book Ideation develops these eight elements through conversation, not interrogation:
+
+| Element | Core Question |
+|---------|---------------|
+| **The Reader** | Who specifically is this for? (situation, beliefs, struggles) |
+| **The Transformation** | Where will they be after reading? (before/after states) |
+| **The Core Thesis** | What's the one big idea someone can disagree with? |
+| **The Author Angle** | Why are you the one to write this? |
+| **The Stakes** | Why does this matter? Why now? |
+| **The Key Concepts** | What 3-7 major ideas support the thesis? |
+| **The Enemy** | What is this book arguing against? |
+| **The Promise** | In one sentence, what does the reader get? |
+
+### Element Deep Dives
+
+**The Reader** - Go beyond demographics. Understand their current situation, what they believe that isn't serving them, what they've tried that hasn't worked, and the trigger moment that would make them pick up this book.
+
+**The Transformation** - Define the gap between Point A (before) and Point B (after). What will they believe differently? What will they be able to do? How will they feel?
+
+**The Core Thesis** - This is a claim, not a topic. Test it: Can someone disagree? Does it challenge conventional wisdom? Template: "Most people believe [X], but actually [Y], because [Z]."
+
+**The Author Angle** - Credibility comes from experience, expertise, access, or perspective. You need at least one that's compelling.
+
+**The Stakes** - What's the cost of NOT reading this book? Why is this moment in time right for this message?
+
+**The Key Concepts** - The 3-7 building blocks that make the thesis credible and actionable. Force prioritization--what's essential vs. nice-to-have?
+
+**The Enemy** - Every great nonfiction book has a villain: a mindset, practice, conventional wisdom, or competing approach. The enemy clarifies the thesis by contrast.
+
+**The Promise** - The value proposition in one sentence. Template: "This book will help [reader] achieve [transformation] by [method/insight]."
+
+## Inputs & Outputs
+
+### Inputs
+
+| Input | Required | Source |
+|-------|----------|--------|
+| Raw idea or brainstorm material | Yes | User |
+| Previous Book Concept Document | For continuing | Previous session |
+
+### Outputs
+
+| Output | Description |
+|--------|-------------|
+| Book Concept Document | Versioned document with all eight elements, session log, open questions, and readiness assessment |
+
+## Best Practices
+
+### When Stuck on an Element
+
+- **Skip and return** - Other elements may clarify it
+- **Ideal Reader Interview** - Imagine interviewing your specific reader
+- **Anti-Book technique** - What's the opposite book? Who's it for?
+
+### Collaboration Behaviors
+
+Claude will:
+- Surface what's implicit: "It sounds like you're really saying..."
+- Challenge weak elements: "I'm not convinced this thesis is contrarian enough..."
+- Connect elements: "Your enemy suggests your reader might be someone who..."
+- Push for specificity: "Can you give me an example of this reader?"
+
+### Quick Capture Mode
+
+For rapid concept capture when time is short:
+1. Share raw idea
+2. Extract rough Reader, Transformation, Thesis, Promise
+3. Create minimal v1 document
+4. Note: "Quick capture--expand in future session"
+
+## Integration
+
+### Pipeline Position
+
+```
+[Raw Idea] --> book-ideation --> [Book Concept Document]
+```
+
+Book Ideation is the entry point for the Non-Fiction Book Factory pipeline.
+
+### Upstream Skills
+
+| Skill | What It Provides |
+|-------|------------------|
+| brainstorm | Raw brainstorm documents as starting material (optional) |
+
+### Downstream Skills
+
+| Skill | What It Receives |
+|-------|------------------|
+| book-idea-validator | Book Concept Document for intellectual stress-testing |
+| book-market-research | Book Concept Document for commercial viability assessment |
+| book-architect | Book Concept Document for structural design (after validation) |
+
+## Examples
+
+### Example 1: Starting from a Raw Idea
+
+**User input:**
+```
+I want to write a book about how paper-based note-taking is superior to
+digital tools for deep thinking.
+```
+
+**Claude's approach:**
+- Probes for the specific reader (who is frustrated with digital tools?)
+- Explores the transformation (from scattered digital notes to coherent thinking?)
+- Sharpens the thesis (what specifically makes paper better?)
+- Identifies the enemy (productivity apps? Notion? Second Brain systems?)
+
+### Example 2: Refining an Existing Concept
+
+**User input:**
+```
+I have this Book Concept Document from last session but my thesis feels weak.
+Here it is: [document]
+```
+
+**Claude's approach:**
+- Reviews the thesis against the "contrarian enough?" test
+- Explores what the thesis is really claiming
+- Connects thesis back to reader's struggles and transformation
+- Tests formulations until one clicks
+
+### Example 3: Quick Capture
+
+**User input:**
+```
+I only have 10 minutes but I had an idea I don't want to lose:
+"Philosophy departments have failed to produce practical wisdom
+because they've abandoned the pursuit of truth."
+```
+
+**Claude's approach:**
+- Captures rough Reader, Transformation, Thesis, Promise
+- Creates minimal v1 document
+- Notes gaps to explore later
+- Enables quick exit without losing the core
+
+## Readiness Criteria
+
+A Book Concept Document is ready for downstream skills when:
+
+| Element | Readiness Test |
+|---------|----------------|
+| Reader | Can describe them as a specific person, not a category |
+| Transformation | Clear before/after with emotional and practical dimensions |
+| Thesis | One sentence, contrarian, defensible |
+| Author Angle | At least one compelling credibility source |
+| Stakes | Urgency is clear--reader feels cost of inaction |
+| Key Concepts | 3-7 prioritized, each clearly supporting the thesis |
+| Enemy | Named and specific |
+| Promise | One sentence that a reader would find compelling |

--- a/docs/skills/non-fiction-book-factory/book-market-research.md
+++ b/docs/skills/non-fiction-book-factory/book-market-research.md
@@ -1,0 +1,240 @@
+# Book Market Research
+
+> Assess commercial viability of book concepts for Amazon KDP self-publishing. Produces a Market Research Report with viability scorecard and Go/No-Go recommendation. Works standalone or after idea-validator.
+
+---
+
+## Overview
+
+The Book Market Research skill determines if a book is worth writing from a business perspective, specifically for Amazon KDP self-publishing. It answers the question: "Setting aside whether this is a good idea, can it succeed commercially?"
+
+A key insight: **commercial viability is separate from intellectual merit.** A brilliant idea can fail commercially. A mediocre idea can succeed. This skill assesses the market, not the idea itself.
+
+Author intent shapes interpretation—the same viability score means different things depending on whether you're writing for income, authority, passion, or lead generation.
+
+---
+
+## Quick Start
+
+### Prerequisites
+
+- Book Concept Document (required)
+- Validation Report (optional but recommended)
+
+### Basic Usage
+
+=== "Claude Code"
+
+    ```markdown
+    When researching book market viability, read and follow /path/to/claude-skills/non-fiction-book-factory/book-market-research/SKILL.md.
+    ```
+
+=== "Claude.ai"
+
+    Upload `book-market-research.skill` to Settings → Skills.
+
+**Sample prompt:**
+```
+I want to assess the commercial viability of my book concept. Here's my Book Concept Document: [paste document]
+```
+
+---
+
+## Features
+
+| Feature | Description |
+|---------|-------------|
+| **Author Intent Calibration** | Interprets scores based on your goals (income, authority, passion, lead gen) |
+| **Quick Assessment Mode** | Single-session qualitative analysis |
+| **Deep Dive Mode** | Multi-session with quantitative Amazon data |
+| **8-Criterion Viability Scorecard** | Weighted scoring across key factors |
+| **Positioning Recommendations** | How to differentiate in the market |
+| **Pricing Guidance** | Market-informed pricing strategy |
+
+---
+
+## Session Modes
+
+### Quick Assessment (Single Session)
+
+- Claude-only qualitative analysis via web search
+- Identifies competitors, positioning gaps, review themes
+- Produces preliminary viability assessment
+- **Best for:** Early-stage filtering, passion/legacy authors, experienced KDP authors
+
+### Deep Dive (Multi-Session)
+
+- Full qualitative analysis PLUS quantitative data
+- Claude provides pre-filled CSV with competitor URLs
+- You gather BSR, prices, review counts from Amazon
+- Claude analyzes completed data for full scorecard
+- **Best for:** Income-focused authors, competitive categories, first-time KDP authors
+
+---
+
+## Author Intent
+
+Your intent determines how to interpret the viability score:
+
+| Intent | Description | Score Interpretation |
+|--------|-------------|---------------------|
+| **Income** | Book must generate revenue | Score is decisive—low = revise or kill |
+| **Authority** | Book is a credential | Moderate score OK if positioning strong |
+| **Passion/Legacy** | "This book needs to exist" | Low score = proceed with eyes open |
+| **Lead Generation** | Funnel for services | Score less critical if book serves funnel |
+| **Audience Service** | Serving existing followers | Platform strength matters more |
+
+---
+
+## Viability Scorecard
+
+| Criterion | Weight | What It Measures |
+|-----------|--------|------------------|
+| Market Demand | 25% | Are people buying books in this space? |
+| Review Landscape | 15% | Review patterns, gap signals from complaints |
+| Competition Gap | 15% | Differentiation opportunity |
+| Author Credibility | 15% | Does background match claims? |
+| Pricing Viability | 10% | Can price competitively with margin? |
+| Author Platform | 10% | Existing audience for launch velocity |
+| Timing | 5% | Trend momentum vs. evergreen |
+| Production Feasibility | 5% | Can this realistically be written? |
+
+---
+
+## Score Interpretation
+
+| Score | Label | Meaning |
+|-------|-------|---------|
+| 7.0+ | **Strong Go** | Market conditions favor success |
+| 5.5–6.9 | **Conditional Go** | Viable with strategic adjustments |
+| 4.0–5.4 | **Revise** | Significant concerns—reposition or reconsider |
+| <4.0 | **Kill** | Market conditions unfavorable |
+
+**Intent Overlay:**
+
+- Income authors: Follow score literally
+- Authority authors: Conditional Go sufficient if positioning strong
+- Passion authors: Even Kill score = proceed with eyes open
+- Lead Gen authors: Platform fit matters more than raw score
+
+---
+
+## Workflow
+
+### Starting Research
+
+1. Provide Book Concept Document (and Validation Report if available)
+2. Claude asks about author intent
+3. Claude recommends session mode with reasoning
+4. You confirm mode
+5. Proceed to research
+
+### Quick Assessment Flow
+
+1. Search for competing books
+2. Analyze: competitor positioning, bestseller signals, review themes
+3. Identify market gaps
+4. Assess author credibility fit
+5. Produce preliminary Market Research Report
+
+### Deep Dive Flow
+
+**Phase 1:** Quick Assessment steps + identify 5-8 key competitors
+
+**Phase 2:** Claude generates pre-filled CSV; you gather Amazon data (~10 min)
+
+**Phase 3:** Claude analyzes completed data for full scorecard
+
+---
+
+## Inputs & Outputs
+
+### Inputs
+
+| Input | Required | Source |
+|-------|----------|--------|
+| Book Concept Document | Yes | book-ideation |
+| Validation Report | Recommended | book-idea-validator |
+| Author intent declaration | Yes | Asked at session start |
+
+### Outputs
+
+| Output | Description |
+|--------|-------------|
+| Market Research Report | Full analysis with scorecard and recommendation |
+| Competitor Analysis CSV | Quantitative data (Deep Dive only) |
+| Positioning Recommendations | How to differentiate |
+| Pricing Recommendations | Market-informed pricing |
+| Title/Subtitle Direction | Market-informed suggestions |
+
+---
+
+## Market Research Report Structure
+
+1. **Executive Summary** — Overall assessment and recommendation
+2. **Author Intent & Interpretation** — How intent shapes recommendation
+3. **Viability Scorecard** — Weighted scores with reasoning
+4. **Competitive Landscape** — Top competitors and gaps
+5. **Target Reader Analysis** — Refined persona, underserved needs
+6. **Positioning Recommendation** — How to differentiate
+7. **Pricing Recommendation** — Based on market analysis
+8. **Title/Subtitle Direction** — Market-informed suggestions
+9. **Platform Fit Assessment** — Existing audience leverage
+10. **Timing Assessment** — Trend vs. evergreen
+11. **Key Risks** — What could derail success
+12. **Recommendation** — Go / Conditional Go / Revise / Kill
+
+---
+
+## Best Practices
+
+- **Declare intent honestly** — It shapes interpretation
+- **Do the data gathering** — 10 minutes on Amazon provides valuable quantitative insight
+- **Consider both validation and market** — Intellectual merit ≠ commercial viability
+- **Use positioning guidance** — The how-to-differentiate matters as much as go/no-go
+
+---
+
+## Integration
+
+### Pipeline Position
+
+```mermaid
+flowchart LR
+    A[book-ideation] --> B[book-idea-validator]
+    B --> C[book-market-research]
+    C --> D[book-architect]
+```
+
+### Dependency Modes
+
+**Standalone Mode:** Book Concept Document only → pure commercial analysis
+
+**Post-Validation Mode:** Book Concept Document + Validation Report → integrated assessment
+
+### Upstream Skills
+
+- **book-ideation** — Provides Book Concept Document
+- **book-idea-validator** — Provides Validation Report (optional)
+
+### Downstream Skills
+
+- **book-architect** — Receives Market Research Report + positioning guidance
+
+---
+
+## Scope Boundaries
+
+This skill assesses **commercial viability**, not:
+
+- Intellectual merit (that's [book-idea-validator](book-idea-validator.md))
+- Book structure (that's [book-architect](book-architect.md))
+- Writing quality (that's the editing pipeline)
+
+---
+
+## Related Skills
+
+- [Book Idea Validator](book-idea-validator.md) — Intellectual merit assessment
+- [Book Ideation](book-ideation.md) — Create the concept document
+- [Book Architect](book-architect.md) — Next step after market research

--- a/docs/skills/non-fiction-book-factory/book-research-assistant.md
+++ b/docs/skills/non-fiction-book-factory/book-research-assistant.md
@@ -1,0 +1,255 @@
+# Book Research Assistant
+
+> Plan, orchestrate, and validate deep research for nonfiction books. The research quality gate—does everything around research (planning, prompting, validating, organizing) while you execute actual deep research using Claude and Gemini.
+
+---
+
+## Overview
+
+The Book Research Assistant plans, orchestrates, and validates deep research for nonfiction books. This skill is the research quality gate—it handles everything around the research (planning, prompting, validating, organizing, certifying readiness) while you execute the actual deep research using Claude and Gemini externally.
+
+Core principles guide this work: **reader-first research** (every gap filled serves the reader's transformation), **truth over thesis** (if research contradicts the book's argument, surface it immediately), and **verify everything** (LLM research can hallucinate—sources need checking).
+
+---
+
+## Quick Start
+
+### Prerequisites
+
+- Research Gaps Document (from book-architect)
+- Book Concept Document (from book-ideation)
+- Master Architecture Document (from book-architect)
+- Section Blueprint Documents (from book-architect)
+
+### Basic Usage
+
+=== "Claude Code"
+
+    ```markdown
+    When planning or validating book research, read and follow /path/to/claude-skills/non-fiction-book-factory/book-research-assistant/SKILL.md.
+    ```
+
+=== "Claude.ai"
+
+    Upload `book-research-assistant.skill` to Settings → Skills.
+
+**Sample prompt:**
+```
+I'm ready to start research for my book. Here are my architecture documents: [paste documents]
+```
+
+---
+
+## Features
+
+| Feature | Description |
+|---------|-------------|
+| **Two-Phase Operation** | Planning (generate prompts) + Validation (verify outputs) |
+| **Gap Expansion** | Identifies gaps architect may have missed |
+| **Self-Contained Prompts** | Each prompt includes full context for standalone use |
+| **7-Dimension Validation** | Coverage, depth, source quality, contradictions, thesis tension, usability, gap spawning |
+| **Dual-Model Requirement** | Both Claude and Gemini outputs for P1 gaps |
+| **Chapter Summaries** | Distills findings per chapter |
+| **Final Synthesis** | Book-wide research synthesis with readiness certification |
+
+---
+
+## Two Phases
+
+### Phase 1: Research Planning
+
+- Review and expand gaps from book-architect
+- Generate self-contained research prompts
+- Initialize tracking documents
+
+### Phase 2: Research Validation
+
+- Review research outputs gap by gap
+- Render verdicts (Complete, Needs More, Problematic)
+- Produce chapter summaries
+- Certify readiness for next phase
+
+---
+
+## Workflow
+
+### Smart Triage at Session Start
+
+Claude guides you to the right entry point:
+
+| Scenario | What to Provide | Next Action |
+|----------|-----------------|-------------|
+| New book, first chapter | All upstream docs | Initialize trackers, start planning |
+| Continuing, new chapter | Book-Level Tracker | Initialize Chapter Tracker |
+| Continuing, validation | Trackers + research files | Begin gap-by-gap validation |
+| Thesis pivot | All docs | Assess impact, regenerate prompts |
+| Final synthesis | All Chapter Summaries | Produce Final Research Synthesis |
+
+### Planning Flow
+
+1. **Review Architect's Gaps** — Assess if well-formed and specific enough
+2. **Expand and Enhance** — Determine evidence types, proof burdens
+3. **Initialize Chapter Tracker** — All gaps with IDs, priorities, statuses
+4. **Generate Research Prompts** — Self-contained prompts for each gap
+5. **Update Trackers** — Mark all gaps as "Prompt Ready"
+
+### Research Prompt Structure
+
+Each prompt includes:
+
+1. Book Context (thesis, reader, transformation)
+2. Chapter Context (position, purpose, entry/exit states)
+3. The Research Gap (ID, priority, clear statement)
+4. Author's Existing Position
+5. Evidence Type Needed
+6. Scope & Boundaries
+7. Source Requirements
+8. Quality Criteria
+9. Search Guidance
+10. Special Requests
+11. Output Format
+
+### Validation Flow
+
+For each gap:
+
+1. **Confirm Gap** — State which gap is being validated
+2. **Request Research** — Claude + Gemini outputs
+3. **Thorough Review** — Assess against 7 dimensions
+4. **Render Verdict** — Complete / Needs More / Problematic
+5. **Update Tracker** — Status, model coverage, quality verdict
+6. **Proceed** — Next gap
+
+---
+
+## Validation Dimensions
+
+| Dimension | Question |
+|-----------|----------|
+| Coverage | Did the research actually answer the question? |
+| Depth | Enough evidence for how chapter will use it? |
+| Source Quality | Verifiable, authoritative, properly cited? |
+| Contradiction Check | Did Claude and Gemini agree? |
+| Thesis Tension | Anything challenge the book's thesis? |
+| Usability | Specific, quotable, concrete for drafting? |
+| Gap Spawning | Did answering reveal NEW gaps? |
+
+---
+
+## Verdicts
+
+| Verdict | Meaning | Action |
+|---------|---------|--------|
+| **Complete** | Research satisfies all dimensions | Gap is filled |
+| **Needs More** | Research fell short | Follow-up prompt generated |
+| **Problematic** | Thesis tension or serious issue | Author decision required |
+
+---
+
+## Inputs & Outputs
+
+### Inputs
+
+| Input | Required | Source |
+|-------|----------|--------|
+| Research Gaps Document | Yes | book-architect |
+| Book Concept Document | Yes | book-ideation |
+| Master Architecture Document | Yes | book-architect |
+| Section Blueprint Documents | Yes | book-architect |
+| Research outputs | During validation | Claude + Gemini |
+
+### Outputs
+
+| Document | Description |
+|----------|-------------|
+| **Book-Level Research Tracker** | Status of all chapters |
+| **Chapter Research Tracker** | Gaps, statuses, verdicts per chapter |
+| **Research Prompt Files** | One per gap, fully self-contained |
+| **Follow-up Prompt Files** | For "Needs More" scenarios |
+| **Chapter Research Summary** | Distillation of findings per chapter |
+| **Final Research Synthesis** | Book-wide synthesis + readiness certification |
+
+---
+
+## Chapter Completion Checklist
+
+- [ ] All P1 gaps marked Complete
+- [ ] All P2 gaps Complete or explicitly deferred
+- [ ] P3 gaps addressed or consciously skipped
+- [ ] No unresolved "Problematic" verdicts
+- [ ] Both models run for P1 gaps
+- [ ] Source quality sufficient for fact-checking
+- [ ] No critical gap-spawned items unaddressed
+
+---
+
+## Readiness Criteria
+
+Research phase is complete when:
+
+1. All chapters show Complete on Book-Level Tracker
+2. All Chapter Research Summaries produced
+3. Final Research Synthesis completed
+4. All P1 and P2 gaps filled
+5. No unresolved Problematic verdicts
+6. Architecture feedback consolidated
+7. Author confirms readiness to proceed
+
+---
+
+## Best Practices
+
+- **Work one gap at a time** — Precision over speed
+- **Use both models for P1 gaps** — Claude + Gemini reduces hallucination risk
+- **Surface thesis tensions immediately** — Better to know now
+- **Verify sources** — LLMs hallucinate; check critical citations
+- **Track everything** — The trackers are your map
+
+---
+
+## Integration
+
+### Pipeline Position
+
+```mermaid
+flowchart LR
+    A[book-architect] --> B[book-research-assistant]
+    B --> C[chapter-architect]
+```
+
+### Upstream Skills
+
+- **book-architect** — Provides Research Gaps Document + Architecture docs
+- **book-ideation** — Provides Book Concept Document
+
+### Downstream Skills
+
+- **chapter-architect** — Receives Final Research Synthesis + Chapter Summaries
+
+### Upstream Feedback Loop
+
+If research reveals architectural problems:
+
+- Architecture Feedback consolidated from Chapter Summaries
+- Sent back to **book-architect** for structural revisions
+
+---
+
+## References
+
+The skill loads these as needed:
+
+- `source-evaluation-guide.md` — Assessing source quality
+- `evidence-types-catalog.md` — Types of evidence and when appropriate
+- `research-question-formulation.md` — Turning gaps into sharp questions
+- `deep-research-prompting.md` — Best practices for Claude/Gemini
+- `contradiction-reconciliation.md` — Handling conflicts
+- `proof-burden-matching.md` — What evidence claims require
+
+---
+
+## Related Skills
+
+- [Book Architect](book-architect.md) — Creates the Research Gaps Document
+- [Chapter Architect](chapter-architect.md) — Uses research to plan chapters
+- [Book Ideation](book-ideation.md) — Creates the Book Concept Document

--- a/docs/skills/non-fiction-book-factory/book-research-assistant.md
+++ b/docs/skills/non-fiction-book-factory/book-research-assistant.md
@@ -25,16 +25,18 @@ Core principles guide this work: **reader-first research** (every gap filled ser
 
 === "Claude Code"
 
+    Add to your project's `CLAUDE.md`:
+
     ```markdown
     When planning or validating book research, read and follow /path/to/claude-skills/non-fiction-book-factory/book-research-assistant/SKILL.md.
     ```
 
 === "Claude.ai"
 
-    Upload `book-research-assistant.skill` to Settings → Skills.
+    Upload the packaged `.skill` file via Settings → Skills (build with `python build.py book-research-assistant`).
 
 **Sample prompt:**
-```
+```text
 I'm ready to start research for my book. Here are my architecture documents: [paste documents]
 ```
 

--- a/docs/skills/non-fiction-book-factory/chapter-architect.md
+++ b/docs/skills/non-fiction-book-factory/chapter-architect.md
@@ -1,0 +1,237 @@
+# Chapter Architect
+
+> Plan individual chapters at beat-level granularity. Transforms high-level chapter specs into detailed outlines that guide drafting while preserving creative freedom.
+
+---
+
+## Overview
+
+The Chapter Architect skill transforms a chapter's high-level specification (from book-architect) into a beat-level outline that guides drafting while preserving creative freedom. The result is a compass, not GPS—it points direction and marks waypoints without dictating every turn.
+
+Core philosophy: **reader-first, always.** Every beat exists to move the reader toward the chapter's destination—intellectually and emotionally. Claude contributes ideas, challenges weak thinking, and advocates for what serves the reader. The author has final approval on all decisions.
+
+---
+
+## Quick Start
+
+### Prerequisites
+
+- Architecture Document with chapter specification (from book-architect)
+- Research Dossier for the chapter (from book-research-assistant)
+- Book Concept Document (from book-ideation)
+
+### Basic Usage
+
+=== "Claude Code"
+
+    ```markdown
+    When planning chapter outlines, read and follow /path/to/claude-skills/non-fiction-book-factory/chapter-architect/SKILL.md.
+    ```
+
+=== "Claude.ai"
+
+    Upload `chapter-architect.skill` to Settings → Skills.
+
+**Sample prompt:**
+```
+I'm ready to architect Chapter 3. Here's the chapter spec from my Architecture Document and the research dossier: [paste documents]
+```
+
+---
+
+## Features
+
+| Feature | Description |
+|---------|-------------|
+| **Beat-Level Planning** | Detailed structure without over-prescription |
+| **Compass Not GPS** | Direction and waypoints, not every turn |
+| **Emotional Arc Tracking** | Where reader is intellectually AND emotionally |
+| **Load-Bearing Identification** | Which beats can/can't be moved or cut |
+| **Opening/Closing Deep Dives** | Extra attention to critical moments |
+| **Session Flexibility** | Simple chapters = one session; complex = multiple |
+
+---
+
+## Core Philosophy
+
+1. **Reader-first, always** — Every beat moves reader toward chapter's destination
+
+2. **Compass, not GPS** — Points direction, doesn't dictate every turn
+
+3. **Intent over prescription** — Each beat captures WHY it exists, enabling intelligent adaptation
+
+4. **Emotional arc matters** — Track how reader FEELS, not just what they learn
+
+---
+
+## Workflow
+
+### Phase 1: Orient
+
+Review inputs together and surface tensions, questions, or issues.
+
+**Key questions:**
+
+- Standard chapter or special type? (introduction, conclusion, case study)
+- Is research sufficient? Any gaps?
+- Competing ways to approach this chapter?
+- What's the emotional shape? (tension→release, confusion→clarity)
+
+**Pause point:** If significant unresolved questions emerge, resolve before proceeding.
+
+### Phase 2: Brainstorm Beats
+
+Generate candidate beats without worrying about sequence yet.
+
+1. Review beat vocabulary together
+2. Generate possible beats—both author and Claude contribute
+3. Consider opening options
+4. Consider closing options
+5. Capture all candidates without judging
+
+**Claude's role:** Actively contribute beat ideas, not just record.
+
+### Phase 3: Sequence and Debate
+
+Put beats in order—this is where real collaboration happens.
+
+1. Propose initial sequence
+2. Walk through reader's experience
+3. Debate ordering decisions
+4. Identify load-bearing vs. flexible beats
+5. Cut beats that aren't earning their place
+6. Add beats if gaps emerge
+
+**Pause point:** If sequence isn't clicking, pause. Complex chapters need marinating time.
+
+### Phase 4: Flesh Out Beats
+
+For each beat, define:
+
+- **Beat name and type**
+- **What happens** (loosely described)
+- **Reader destination** (intellectual and emotional—non-negotiable)
+- **Key material** (pointers to research, quotes, examples)
+- **Load-bearing flag** (can this be moved or cut?)
+- **Notes** (anything ghostwriter should know)
+
+**Special attention:** Opening and closing beats get deeper treatment with specific hooks, callbacks, or images.
+
+### Phase 5: Review and Finalize
+
+Stress-test the complete arc before producing the document.
+
+1. Walk through reader's experience beat by beat
+2. Check against common problems
+3. Verify chapter delivers on its job
+4. Confirm bridge to next chapter works
+5. Get final author approval
+6. Produce Chapter Outline Document
+
+---
+
+## Inputs & Outputs
+
+### Inputs
+
+| Input | Required | Source |
+|-------|----------|--------|
+| Architecture Document (chapter spec) | Yes | book-architect |
+| Research Dossier (chapter section) | Yes | book-research-assistant |
+| Book Concept Document | Yes | book-ideation |
+| Author notes on chapter | Optional | Author |
+
+### Outputs
+
+**Chapter Outline Document** containing:
+
+1. **Chapter Context** — Job, entry/exit states, connections, emotional arc, tone notes
+2. **Reader Journey Walkthrough** — Prose narrative of the experience
+3. **Beat Sequence** — Detailed breakdown of each beat
+4. **Opening Deep Dive** — Expanded treatment of opening
+5. **Closing Deep Dive** — Expanded treatment of closing
+
+---
+
+## Beat Elements
+
+Each beat includes:
+
+| Element | Description |
+|---------|-------------|
+| Beat name | Descriptive identifier |
+| Beat type | From vocabulary (claim, story, objection, etc.) |
+| What happens | Loose description of content |
+| Reader destination | Where reader ends up intellectually AND emotionally |
+| Key material | Specific pointers to research |
+| Load-bearing | Yes/No—can this beat move or be cut? |
+| Notes | Guidance for ghostwriter |
+
+---
+
+## Readiness Criteria
+
+Before handoff, confirm:
+
+- [ ] All beats have clear reader destinations (intellectual and emotional)
+- [ ] Load-bearing beats are flagged
+- [ ] Key material is curated and pointed to for each beat
+- [ ] Opening and closing have deep-dive treatment
+- [ ] Reader journey walkthrough captures chapter's feel
+- [ ] Chapter delivers on its job and exit state
+- [ ] Bridge to next chapter is clear
+- [ ] Author has approved the outline
+
+---
+
+## Best Practices
+
+- **Let Claude contribute beats** — The skill is collaborative, not transcription
+- **Debate the sequence** — This is where real value emerges
+- **Flag load-bearing beats clearly** — Protects structure during drafting
+- **Don't skip emotional arc** — HOW reader feels matters as much as what they learn
+- **Give opening/closing extra attention** — These are high-leverage moments
+- **Trust pause points** — Complex chapters need thinking time between sessions
+
+---
+
+## Integration
+
+### Pipeline Position
+
+```mermaid
+flowchart LR
+    A[book-research-assistant] --> B[chapter-architect]
+    B --> C[draft-coach/ghostwriter]
+```
+
+### Upstream Skills
+
+- **book-architect** — Provides Architecture Document with chapter specs
+- **book-research-assistant** — Provides Research Dossier
+
+### Downstream Skills
+
+- **draft-coach** — If author is writing and wants feedback
+- **ghostwriter** — If Claude is drafting (with author approval)
+
+---
+
+## References
+
+The skill loads these as needed:
+
+- `special-chapter-types.md` — Introductions, conclusions, case studies
+- `emotional-arc-patterns.md` — Tension→release, confusion→clarity, etc.
+- `beat-vocabulary.md` — Types of beats available
+- `opening-strategies.md` — How to start chapters
+- `closing-strategies.md` — How to end chapters
+- `common-chapter-problems.md` — Antipatterns to avoid
+
+---
+
+## Related Skills
+
+- [Book Architect](book-architect.md) — Creates chapter specifications
+- [Book Research Assistant](book-research-assistant.md) — Provides research dossier
+- [Book Ideation](book-ideation.md) — Creates Book Concept Document

--- a/docs/skills/non-fiction-book-factory/index.md
+++ b/docs/skills/non-fiction-book-factory/index.md
@@ -1,0 +1,150 @@
+# Non-Fiction Book Factory
+
+> A comprehensive pipeline that replicates traditional publishing infrastructure for nonfiction book creation using specialized Claude skills.
+
+## Overview
+
+The Non-Fiction Book Factory is a suite of six interconnected skills that guide authors from initial idea to chapter-level outlines ready for drafting. Each skill specializes in one phase of the book development process, producing structured output that the next skill consumes.
+
+Traditional publishing provides authors with developmental editors, fact-checkers, market researchers, and structural consultants. Self-published authors typically lack access to this infrastructure. This pipeline replicates that expertise using Claude, creating a "book factory" with specialized skills for each phase.
+
+The factory is built on a core principle: **every decision serves the reader.** The question is never "what do I want to say?" but "what transformation does the reader need, and how can this book deliver it?"
+
+## Pipeline Flow
+
+```mermaid
+flowchart TB
+    subgraph Phase1["Phase 1: Concept Development"]
+        A[book-ideation]
+    end
+
+    subgraph Phase2["Phase 2: Validation"]
+        B[book-idea-validator]
+        C[book-market-research]
+    end
+
+    subgraph Phase3["Phase 3: Architecture"]
+        D[book-architect]
+    end
+
+    subgraph Phase4["Phase 4: Research"]
+        E[book-research-assistant]
+    end
+
+    subgraph Phase5["Phase 5: Chapter Planning"]
+        F[chapter-architect]
+    end
+
+    A -->|Book Concept Document| B
+    B -->|Validation Report| C
+    B -->|Go/No-Go| D
+    C -->|Market Research Report| D
+    D -->|Architecture Documents| E
+    E -->|Research Synthesis| F
+    F -->|Chapter Outlines| G[Ready to Draft]
+
+    B -.->|Revise| A
+    C -.->|Revise| A
+```
+
+## Skills Overview
+
+| Skill | Phase | Purpose | Primary Output |
+|-------|-------|---------|----------------|
+| [Book Ideation](book-ideation.md) | Concept | Develop raw ideas into structured concepts | Book Concept Document |
+| [Book Idea Validator](book-idea-validator.md) | Validation | Stress-test ideas against research | Validation Report |
+| [Book Market Research](book-market-research.md) | Validation | Assess commercial viability | Market Research Report |
+| [Book Architect](book-architect.md) | Architecture | Design structural and emotional architecture | Master Architecture + Section Blueprints |
+| [Book Research Assistant](book-research-assistant.md) | Research | Fill research gaps with validated evidence | Research Synthesis |
+| [Chapter Architect](chapter-architect.md) | Planning | Create beat-level chapter outlines | Chapter Outline Documents |
+
+## When to Use This Pipeline
+
+**Use the Non-Fiction Book Factory when you:**
+
+- Have a nonfiction book idea you want to develop systematically
+- Want to validate ideas before investing months in writing
+- Need structured architecture that serves the reader's journey
+- Want to ensure your book stands out in the marketplace
+- Are self-publishing through Amazon KDP
+- Want a repeatable, professional process for book development
+
+**This pipeline is NOT for:**
+
+- Fiction (requires different approaches)
+- Quick ebooks or lead magnets (see Ebook Factory)
+- Academic papers or articles
+- Blog post series
+
+## Philosophy and Approach
+
+### Reader-First Decision Making
+
+Every decision in the pipeline--structural, stylistic, content--is evaluated from the reader's perspective:
+
+- Will this help the reader understand?
+- Will this keep the reader engaged?
+- Will this move the reader toward transformation?
+
+### Validate Before Investing
+
+The pipeline includes explicit validation gates to prevent wasted effort. Phase 2 (Validation) provides a Go/Revise/Kill decision point before committing to architecture and drafting.
+
+### Honest Feedback
+
+Skills are designed to challenge weak thinking and surface problems early. Claude functions as an intellectual partner, not a yes-man. Better to kill a weak idea now than to finish a weak book later.
+
+### Explicit Handoffs
+
+Each skill produces structured output that the next skill consumes. Documents are versioned (v1, v2, v3) so progress can be tracked and earlier versions referenced.
+
+## Workflow
+
+1. **Start with ideation** - Run `book-ideation` to develop your raw idea into a structured concept with eight core elements
+
+2. **Validate the concept** - Run `book-idea-validator` to stress-test against research, then `book-market-research` to assess commercial viability
+
+3. **Make the Go/No-Go decision** - Review both reports and decide whether to proceed, revise, or kill the project
+
+4. **Architect the book** - Run `book-architect` to design the complete structural and emotional architecture
+
+5. **Conduct research** - Run `book-research-assistant` to plan research prompts, execute deep research externally, then validate findings
+
+6. **Plan each chapter** - Run `chapter-architect` to create beat-level outlines for individual chapters before drafting
+
+## Key Documents
+
+The pipeline produces these core artifacts:
+
+| Document | Created By | Used By |
+|----------|-----------|---------|
+| Book Concept Document | book-ideation | idea-validator, market-research, book-architect |
+| Validation Report | book-idea-validator | market-research, book-architect |
+| Market Research Report | book-market-research | book-architect |
+| Master Architecture Document | book-architect | book-research-assistant, chapter-architect |
+| Section Blueprint Documents | book-architect | book-research-assistant, chapter-architect |
+| Research Gaps Document | book-architect | book-research-assistant |
+| Chapter Research Summaries | book-research-assistant | chapter-architect |
+| Final Research Synthesis | book-research-assistant | chapter-architect |
+| Chapter Outline Documents | chapter-architect | draft-coach, ghostwriter |
+
+## Getting Started
+
+1. **Prepare your starting material** - This can be:
+   - A raw idea (one sentence or paragraph)
+   - Brainstorm documents
+   - Zettelkasten notes or research collection
+   - An existing partial concept
+
+2. **Invoke book-ideation** - Share your material and work through the eight elements
+
+3. **Follow the pipeline** - Each skill will guide you to the next step
+
+## Related Resources
+
+- [Book Ideation](book-ideation.md) - Start here
+- [Book Idea Validator](book-idea-validator.md) - Stress-test your concept
+- [Book Market Research](book-market-research.md) - Assess viability
+- [Book Architect](book-architect.md) - Design structure
+- [Book Research Assistant](book-research-assistant.md) - Fill research gaps
+- [Chapter Architect](chapter-architect.md) - Plan chapters

--- a/docs/skills/writing/ghost-writer.md
+++ b/docs/skills/writing/ghost-writer.md
@@ -1,0 +1,487 @@
+# Ghost Writer
+
+> Produce first drafts that match a writer's authentic voice using their Voice DNA Document. Consumes DNA documents from writing-dna-discovery skill. Generates 2 meaningfully different drafts with headlines, confidence assessment, decision notes, and DNA refinement suggestions. Collaborative partner that evaluates, pushes back, and advocates for quality. Handles blog posts, essays, newsletters, and more.
+
+## Overview
+
+Ghost Writer produces first drafts at approximately 80% voice accuracy using your Voice DNA Document. This is not a generic writing assistant that produces polished AI prose. This is a tool calibrated to sound like you, applying documented patterns, avoiding documented anti-patterns, and transparently noting where it is confident versus uncertain.
+
+The skill operates as a collaborative partner, not an order-taker. It evaluates task clarity, surfaces tensions between your DNA and the task requirements, offers honest feedback on approach, and pushes back diplomatically when it sees problems. You always decide, but the skill advocates for quality throughout the process.
+
+Every session produces two meaningfully different drafts. These are not minor variations but distinct approaches: perhaps one narrative and one analytical, one with a bold hook and one with scene-setting, one emphasizing certain aspects while the other highlights different ones. This gives you options and reveals trade-offs rather than presenting a single "correct" interpretation.
+
+## Quick Start
+
+### Prerequisites
+
+- **Voice DNA Document** (required): Output from Writing DNA Discovery skill
+- **Writing task**: What you want to write, for whom, and why
+- Optional: Research materials, prior pieces in a series, tone modifiers
+
+### Basic Usage
+
+```
+I need a blog post about remote work productivity for my developer audience.
+
+[Voice DNA Document]
+
+Key points to cover:
+- Async communication reduces interruptions
+- Focus time blocks are essential
+- Written documentation prevents information loss
+```
+
+The skill will verify your DNA document, summarize the task, surface any concerns, then produce two drafts with headlines, notes, and a comparison.
+
+## Features
+
+### Voice DNA Consumption
+
+The skill reads and applies your complete Voice DNA Document:
+
+- **Quick Reference**: Core temperature, sentence signature, distinctive moves
+- **Ghost Writer Briefing**: Do This, Don't Do This, When Uncertain rules
+- **Voice Profile**: Dimension-by-dimension patterns with status indicators
+- **Exemplar Passages**: Models of your voice in action
+- **Anti-Patterns**: Patterns to actively avoid
+- **Profile Metadata**: Readiness level and confidence per dimension
+
+The skill applies patterns from the full document, not just the briefing section.
+
+### Dual-Draft Approach
+
+Every session produces two meaningfully different drafts. Differences might include:
+
+| Dimension | Draft A | Draft B |
+|-----------|---------|---------|
+| Structure | Narrative arc | Analytical breakdown |
+| Opening | Bold claim hook | Scene-setting lead |
+| Tone | Within documented range, more urgent | Within documented range, more measured |
+| Emphasis | Problem-focused | Solution-focused |
+
+Both drafts apply your voice patterns; the difference is in strategic choices within those patterns.
+
+### Confidence Assessment
+
+Each output includes transparent confidence reporting:
+
+```
+## Confidence Assessment
+
+**Profile Readiness:** Solid
+**Profile Freshness:** Created 2 months ago
+**Estimated Accuracy:** ~80%
+**Key Uncertainties:** Humor approach (Emerging status), paragraph transitions (inferred)
+```
+
+The skill tells you where it is confident, where it is inferring, and where gaps in your DNA document affect output quality.
+
+### Decision Documentation
+
+Each draft includes notes explaining choices made:
+
+```
+## Draft A Notes
+
+**Approach:** Opened with the async communication point as a challenge to
+common "more meetings" advice. Built the argument through negation before
+offering the solution.
+
+**Patterns Applied:**
+- Short punchy sentences for main points (documented): "Meetings are not work."
+- Em-dash for dramatic pause (documented): "The problem isn't communication—it's interruption."
+- Direct reader address (documented): "You've been in that meeting."
+
+**Decisions Made:**
+- Chose not to use humor per DNA guidance (flag rather than attempt)
+- Opened with challenge pattern matching your blog samples
+
+**Uncertainties:**
+- Paragraph transition style: DNA shows varied approaches, defaulted to implicit flow
+```
+
+### Feedback Loop
+
+After reviewing drafts, the skill collects structured feedback:
+
+> "Before we continue, I'd like to capture what worked and what didn't:
+>
+> 1. What felt most authentically 'you' in these drafts?
+> 2. Anything that felt off or not quite your voice?
+> 3. Any patterns I should lean into more, or avoid?"
+
+Feedback translates into DNA refinement suggestions you can apply yourself or through a discovery session.
+
+### Supported Formats
+
+- Blog posts
+- Essays and articles
+- Newsletters
+- LinkedIn posts
+- Twitter/X threads
+- Long-form content (2000+ words with section-by-section option)
+
+## Workflow
+
+### Phase 1: Intake
+
+**DNA Document Review:**
+- Read full document, not just briefing
+- Note readiness level (Minimum Viable, Solid, Strong)
+- Check freshness (flag if 6+ months old)
+- Identify voice strengths and gaps
+
+**Task Receipt:**
+- Accept free-form task descriptions
+- Ask targeted follow-ups only for missing key information:
+  - Topic/subject
+  - Audience
+  - Purpose (inform, persuade, entertain, inspire)
+  - Context/publication
+  - Length requirements
+
+**Pre-Draft Checks:**
+
+| Check | Action |
+|-------|--------|
+| Register Match | Verify DNA register matches task type |
+| Research Sufficiency | Review provided research, identify gaps |
+| Sensitive Topics | Confirm approach for controversial content |
+| Multiple Audiences | Clarify priority or request audience-specific versions |
+| Series Context | Request prior parts for consistency |
+| Derivative Work | Request existing content to match |
+| Tone Modifiers | Accept "my voice, but more X" as layer on DNA |
+
+### Phase 2: Pre-Draft Verification
+
+**Voice Strength Preview:**
+> "Based on your DNA document:
+>
+> - **Strong:** Sentence rhythm, punctuation, word choice
+> - **Moderate:** Opening patterns, reader relationship
+> - **Light:** Humor approach, closing moves
+>
+> I'll be most confident in Strong areas. Any guidance for the Light areas before I draft?"
+
+**Task Summary:**
+Confirm understanding of core message, audience, key points, and planned approach.
+
+**Concerns:**
+Surface any tensions or potential issues before drafting.
+
+### Phase 3: Drafting
+
+**Apply Voice Patterns:**
+- Use documented patterns: sentence rhythm, punctuation, word choice, tone
+- Follow "Do This" items explicitly
+- Avoid "Don't Do This" items strictly
+- Apply "When Uncertain" rules for ambiguous decisions
+- Note when inferring vs. following documented patterns
+
+**Suppress Anti-Patterns:**
+- Apply DNA document's specific anti-patterns
+- Apply baseline anti-AI patterns
+- Revise before delivering if AI tells slip in
+
+**Headlines:**
+- 2-3 options per draft
+- Follow DNA headline patterns if captured
+- Otherwise: one direct, one curiosity-driven, one benefit-focused
+
+**Long-Form Considerations (2000+ words):**
+- Offer section-by-section workflow with feedback between sections
+- Re-ground in voice patterns at section breaks
+- Run consistency check across full piece
+- Monitor rhythm variation; flag monotony
+
+**Humor:**
+- Conservative approach
+- Flag opportunities rather than attempting
+- Let you add humor during revision
+
+### Phase 4: Output Delivery
+
+Structured output in this order:
+
+1. **Confidence Header**: Profile readiness, freshness, estimated accuracy, uncertainties
+2. **Draft A**: Descriptor, 2-3 headlines, clean prose content
+3. **Draft A Notes**: Approach, patterns applied, decisions, uncertainties
+4. **Draft B**: Descriptor (how it differs), headlines, content
+5. **Draft B Notes**: Same structure as Draft A
+6. **Comparison**: What each emphasizes, when to use each, observations
+7. **Consistency Check**: (Long pieces only) Drift, rhythm notes, recommendations
+
+### Phase 5: Feedback Collection
+
+Structured questions after review:
+
+> "1. What felt most authentically 'you' in these drafts?
+> 2. Anything that felt off or not quite your voice?
+> 3. Any patterns I should lean into more, or avoid?"
+
+Listening for confirmations, corrections, gaps, and new anti-patterns.
+
+### Phase 6: DNA Refinement Suggestions
+
+```
+## Suggested DNA Refinements
+
+Based on your feedback, consider these updates:
+
+**Add to Anti-Patterns:**
+- "Despite challenges..." - felt too formulaic
+
+**Strengthen in Voice Profile:**
+- Paragraph transitions: prefer implicit over explicit
+
+**Add to "When Uncertain":**
+- Default to shorter paragraphs over longer
+```
+
+### Phase 7: Iteration
+
+| User Says | Action |
+|-----------|--------|
+| "Draft A is close, but..." | Revise A based on notes, maintain voice |
+| "Neither is quite right" | Explore what is missing, potentially Draft C |
+| "Good enough, I'll take it from here" | End session, optionally collect final feedback |
+| "Let's keep going" | Continue iteration |
+
+During iteration:
+- Ask for clarification rather than guessing on unclear notes
+- Offer perspective on requested changes
+- Track what changed between versions
+- Maintain voice consistency across iterations
+
+## Inputs and Outputs
+
+### Inputs
+
+| Input | Required | Description |
+|-------|----------|-------------|
+| Voice DNA Document | Required | Output from Writing DNA Discovery |
+| Writing task | Required | Topic, audience, purpose, context |
+| Research/materials | Optional | Background information, data, sources |
+| Prior pieces | Optional | For series consistency |
+| Tone modifiers | Optional | "my voice, but more urgent" |
+| Platform | Optional | LinkedIn, newsletter, blog, Twitter |
+
+### Outputs
+
+**For each session:**
+
+- **Confidence Assessment**: Readiness, freshness, accuracy estimate, uncertainties
+- **Draft A**: Headlines + clean prose + notes
+- **Draft B**: Headlines + clean prose + notes (meaningfully different approach)
+- **Comparison Summary**: When to use each, observations
+- **DNA Refinement Suggestions**: Based on feedback (after iteration)
+
+## Best Practices
+
+### Before the Session
+
+- Ensure Voice DNA Document is reasonably current (less than 6 months)
+- Prepare research and reference materials in advance
+- Know your audience and purpose clearly
+- Have prior pieces ready if continuing a series
+
+### During Drafting
+
+- Trust the confidence assessment; be appropriately skeptical where indicated
+- Read drafts aloud to hear voice patterns
+- Focus feedback on voice accuracy, not just content quality
+- Give specific feedback: "I would never use this phrase" is more useful than "this feels off"
+
+### After Drafting
+
+- Consider DNA refinement suggestions seriously
+- Return to DNA Discovery if systematic issues emerge
+- Add the 20% yourself: creative spark, situational judgment, final polish
+
+### Platform Considerations
+
+| Platform | Key Adjustments |
+|----------|-----------------|
+| LinkedIn | Professional framing, hook in first line, mobile-scannable |
+| Newsletter | Personal connection, value delivery, consistent sign-off |
+| Twitter/X | Thread structure, hook tweet, each tweet self-contained |
+| Blog | SEO considerations if relevant, scannability, deeper engagement |
+
+## Integration
+
+### Pipeline Position
+
+Ghost Writer is the downstream skill in the Writing Pipeline. It consumes Voice DNA Documents and produces drafts.
+
+```
+Writing DNA Discovery --> Voice DNA Document --> Ghost Writer --> Drafts --> Your Editing
+```
+
+### Upstream Skills
+
+- **Writing DNA Discovery**: Produces the required Voice DNA Document
+
+### Downstream Skills
+
+None in the current pipeline. Ghost Writer output goes to you for editing and finalization.
+
+### Cross-Pipeline Integration
+
+- Drafts can feed into any editing or review workflow
+- Multiple drafts can inform A/B testing for newsletters
+- Confidence notes inform how much editing to expect
+
+## Examples
+
+### Example 1: Blog Post Request
+
+**User Input:**
+```
+Blog post about why documentation matters for engineering teams.
+Audience: engineering managers.
+Goal: convince them to invest in documentation culture.
+
+[Voice DNA Document attached]
+```
+
+**Skill Response (abbreviated):**
+
+```
+## Confidence Assessment
+
+**Profile Readiness:** Solid
+**Profile Freshness:** Created 6 weeks ago
+**Estimated Accuracy:** ~80%
+**Key Uncertainties:** Humor approach (Emerging), technical jargon level (inferred from samples)
+
+## Draft A: The Challenge Approach
+
+### Headlines
+1. Your Team's Documentation Isn't a Nice-to-Have
+2. Documentation Debt Is Slowing Your Team Down
+3. Why Your Best Engineers Keep Asking the Same Questions
+
+### Content
+
+Documentation isn't overhead. It's leverage.
+
+Every time a senior engineer explains the same architecture decision, you're
+spending their salary on knowledge transfer that should have happened once.
+Every time a new hire spends a week figuring out what could have been a
+five-minute read, you're paying an onboarding tax...
+
+[Content continues]
+
+## Draft A Notes
+
+**Approach:** Opened with direct challenge to common framing of documentation
+as optional. Used cost/time framing to appeal to manager priorities.
+
+**Patterns Applied:**
+- Short punchy opener (documented): "Documentation isn't overhead. It's leverage."
+- Em-dash usage (documented): Single dash for pivot, not parenthetical
+- Reader implication (documented): "you're spending their salary"
+...
+```
+
+### Example 2: Tone Modifier
+
+**User Input:**
+```
+Same blog post topic, but I need it more urgent. We just had an incident
+caused by missing documentation and I want to use that energy.
+
+[Voice DNA Document attached]
+```
+
+**Skill Response:**
+> Got it. I'll apply your voice patterns but layer on more urgency. This means:
+>
+> - Shorter sentences than your typical range
+> - More direct imperatives
+> - Less hedging, even where you might normally hedge slightly
+>
+> This stays recognizably you, just with the urgency dial turned up. Ready to draft?
+
+### Example 3: Register Mismatch Handling
+
+**User Input:**
+```
+I need a LinkedIn post about our product launch.
+
+[Voice DNA Document - Blog register]
+```
+
+**Skill Response:**
+> This DNA document captures your blog voice, but you're asking for LinkedIn.
+> Should I:
+>
+> 1. Apply your blog voice to LinkedIn (still recognizably you, may feel slightly off for platform)
+> 2. Adapt for LinkedIn conventions while preserving core patterns (more platform-appropriate, slight voice drift)
+> 3. Create a LinkedIn-native piece (less distinctly your voice, optimized for platform)
+>
+> Or if you have a separate LinkedIn DNA document, share that instead.
+
+## Edge Cases
+
+### Sparse DNA Profile
+
+If profile is Minimum Viable or sparser:
+- Acknowledge lower confidence upfront
+- Be conservative; avoid risky choices
+- Lean on baseline craft principles where DNA does not guide
+- Flag more areas as uncertain
+- Suggest specific dimensions for future discovery
+
+### Conflicting DNA Patterns
+
+When patterns contradict:
+1. Check "When Uncertain" rules first
+2. Apply hierarchy: specific instructions > general tendencies
+3. If still unclear, pick one and explain reasoning
+4. Note the conflict and suggest clarification
+
+### Out-of-Character Requests
+
+If you explicitly ask for something contrary to your DNA:
+> "Your DNA shows a warm, conversational voice, but you're asking for formal
+> and authoritative. Should I:
+>
+> - Shift toward formal while preserving core patterns (still recognizably you)
+> - Go full formal (less distinctly your voice, fits the request)
+> - Something else?"
+
+### Series Consistency
+
+If part of a series:
+- Request prior parts or summary of established patterns
+- Maintain terminology consistency
+- Honor narrative threads
+- Note series considerations in draft notes
+
+## Reference Files
+
+The skill can load these references as needed:
+
+| Category | Files |
+|----------|-------|
+| Voice Application | `voice-consumption-guide.md`, `voice-calibration-techniques.md` |
+| Output Structure | `output-format-guide.md`, `quality-checklist.md` |
+| Session Management | `session-flow-guide.md`, `feedback-collection-protocol.md` |
+| Craft Principles | `elements-of-style.md`, `on-writing-well.md`, `sentence-mastery.md` |
+| Structure | `opening-strategies.md`, `closing-strategies.md`, `transition-mastery.md` |
+| Format-Specific | `blog-writing-guide.md`, `long-form-essay-guide.md`, `platform-conventions.md` |
+| Anti-Patterns | `anti-ai-patterns.md`, `common-writing-weaknesses.md` |
+
+## Key Reminders
+
+1. **You are a collaborative partner**: Evaluate, push back, offer perspective. Do not just execute.
+2. **The human's voice is the goal**: Not "good writing" in the abstract, but writing that sounds like them.
+3. **80% accuracy is the target**: The human adds the final 20%. You are creating a strong starting point.
+4. **Full document, not just briefing**: Read and apply the entire DNA document.
+5. **Two drafts, always**: Offer meaningful choice, not just one path.
+6. **Transparency about confidence**: Be honest about what you are sure of and what you are inferring.
+7. **Conservative with humor**: Flag opportunities rather than attempting.
+8. **Suppress AI patterns**: Both DNA-specific and baseline. If it sounds like AI, revise.
+9. **Surface tensions early**: If something does not fit, say so before drafting.
+10. **The human decides**: After pushback, if they insist, proceed faithfully while noting your concern.

--- a/docs/skills/writing/ghost-writer.md
+++ b/docs/skills/writing/ghost-writer.md
@@ -20,7 +20,7 @@ Every session produces two meaningfully different drafts. These are not minor va
 
 ### Basic Usage
 
-```
+```text
 I need a blog post about remote work productivity for my developer audience.
 
 [Voice DNA Document]

--- a/docs/skills/writing/index.md
+++ b/docs/skills/writing/index.md
@@ -1,0 +1,182 @@
+# Writing Skills
+
+> A pipeline for capturing and replicating a writer's authentic voice.
+
+## Overview
+
+The Writing Skills pipeline solves a fundamental challenge in AI-assisted writing: producing drafts that genuinely sound like you, not like generic AI output. Rather than relying on vague style descriptions or hope, this pipeline takes a systematic approach to voice capture and application.
+
+The workflow has two phases. First, **Writing DNA Discovery** captures the "genetic code" of your voice through collaborative analysis and interview. This produces a structured Voice DNA Document containing patterns, anti-patterns, exemplar passages, and actionable guidance. Second, **Ghost Writer** consumes that document to generate first drafts at approximately 80% voice accuracy. You add the remaining 20%: the creative spark, situational judgment, and final polish.
+
+This is not about replacing the writer. It is about giving you a strong starting point that sounds like you, saving the mental energy of starting from scratch while preserving your distinctive voice.
+
+## Pipeline Architecture
+
+```mermaid
+flowchart LR
+    subgraph Discovery["Phase 1: Capture"]
+        WD[Writing DNA Discovery]
+        S[Writing Samples]
+        I[Collaborative Interview]
+        S --> WD
+        I --> WD
+        WD --> DNA[Voice DNA Document]
+    end
+
+    subgraph Production["Phase 2: Generate"]
+        GW[Ghost Writer]
+        T[Writing Task]
+        DNA --> GW
+        T --> GW
+        GW --> D1[Draft A]
+        GW --> D2[Draft B]
+    end
+
+    subgraph Refinement["Feedback Loop"]
+        D1 --> FB[User Feedback]
+        D2 --> FB
+        FB --> GW
+        FB -.->|DNA Updates| WD
+    end
+
+    style DNA fill:#f9f,stroke:#333,stroke-width:2px
+```
+
+## Philosophy
+
+### Voice Authenticity Over "Good Writing"
+
+The goal is not to produce objectively "good" writing. The goal is to produce writing that sounds like you. A distinctive voice may include patterns that writing guides would discourage, but those patterns are part of what makes your writing recognizably yours.
+
+### 80% Accuracy Target
+
+The skills aim for 80% voice accuracy in first drafts. This is intentional. The remaining 20% is where your creative judgment, situational awareness, and final polish come in. These skills accelerate your process; they do not replace your input.
+
+### Living Documents
+
+Your Voice DNA Document is not static. Initial discovery captures the foundation. Return sessions deepen, refine, and adapt as your voice evolves. Each round of ghost writing feedback becomes material for DNA refinement.
+
+### Anti-Patterns Are Critical
+
+What you do not do is as important as what you do. The DNA document captures words, structures, and tones that would make readers think "that is not their writing." This includes AI patterns that must be actively suppressed.
+
+### One Register Per Session
+
+Each discovery session focuses on a single mode: blog posts, fiction prose, technical writing, newsletters. Different contexts may call for different voices. Create separate DNA documents if your voice varies significantly across registers.
+
+## Skills in This Pipeline
+
+| Skill | Purpose | Input | Output |
+|-------|---------|-------|--------|
+| [Writing DNA Discovery](./writing-dna-discovery.md) | Capture voice patterns through interview and sample analysis | Writing samples + conversation | Voice DNA Document |
+| [Ghost Writer](./ghost-writer.md) | Generate first drafts matching captured voice | Voice DNA Document + writing task | Two meaningfully different drafts |
+
+## Readiness Levels
+
+Your Voice DNA Document has a readiness level that affects ghost writing accuracy:
+
+| Level | Accuracy | What It Means |
+|-------|----------|---------------|
+| **Minimum Viable** | 60-70% | 3-5 strong patterns, clear tone, key anti-patterns documented |
+| **Solid** | 75-85% | Multiple dimensions developed, exemplar passages annotated, stress-tested |
+| **Strong** | 85-90% | Deep analysis across dimensions, validated against output, refined from feedback |
+
+## Getting Started
+
+### First-Time Users
+
+1. **Gather writing samples**: Collect 3-5 pieces that represent your authentic voice. Choose writing you are proud of, not pieces that were heavily edited by others.
+
+2. **Run Writing DNA Discovery**: Provide your samples and engage in the collaborative interview. Be honest about what is truly "you" versus aspirational patterns.
+
+3. **Reach Minimum Viable readiness**: Continue the session until the skill confirms at least Minimum Viable status. This typically takes one focused session.
+
+4. **Run Ghost Writer**: Provide your Voice DNA Document and a writing task. Review both drafts, noting what works and what feels off.
+
+5. **Iterate and refine**: Use feedback to improve drafts within the session. After multiple sessions, return to DNA Discovery to refine your profile based on what the ghost writer consistently gets wrong.
+
+### Returning Users
+
+- **New writing task**: Run Ghost Writer with your existing DNA document
+- **Voice has evolved**: Run a DNA Discovery evolution session
+- **Ghost writer keeps missing something**: Run a DNA Discovery refinement session to convert feedback into explicit anti-patterns
+- **New writing context**: Run a DNA Discovery session for the new register (creates a separate DNA document)
+
+## Key Concepts
+
+### Voice Dimensions
+
+The DNA Discovery skill analyzes multiple dimensions of voice:
+
+**Core Dimensions** (always explored):
+- Sentence Rhythm: length variation, internal structure, emphasis placement
+- Punctuation Personality: em-dashes, semicolons, parentheses, comma density
+- Word Choice: vocabulary level, favorites, avoided words
+- Tone and Temperature: warm/cool, formal/casual, confident/hedging
+- Reader Relationship: first person presence, direct address, authority stance
+
+**Extended Dimensions** (as relevant):
+- Opening Moves: how pieces begin
+- Closing Moves: how pieces end
+- Structural Patterns: paragraph construction, transitions
+- Confidence/Hedging: qualifier density, uncertainty handling
+- Humor Approach: type, placement, frequency
+- Signature Elements: distinctive moves, pet phrases
+
+### The Voice DNA Document
+
+The output of DNA Discovery is a structured document containing:
+
+- **Quick Reference**: Core temperature, sentence signature, distinctive moves, never-dos
+- **Voice Profile**: Dimension-by-dimension analysis with examples
+- **Exemplar Passages**: Annotated excerpts demonstrating patterns in action
+- **Anti-Patterns**: What to avoid, including AI patterns to suppress
+- **Ghost Writer Briefing**: Do This, Don't Do This, When Uncertain rules
+- **Profile Metadata**: Readiness level, confidence assessment, gaps
+
+### Dual-Draft Approach
+
+Ghost Writer always produces two meaningfully different drafts. Differences might include:
+
+- Structural approach (narrative vs. analytical)
+- Opening strategy (direct hook vs. scene-setting)
+- Tone variation (within documented range)
+- Emphasis (different aspects highlighted)
+
+This gives you options and reveals trade-offs rather than presenting a single "correct" interpretation.
+
+## When to Use Each Skill
+
+| Scenario | Skill to Use |
+|----------|--------------|
+| First time capturing your voice | Writing DNA Discovery (Initial Discovery) |
+| Adding new samples to existing profile | Writing DNA Discovery (Sample Addition) |
+| Exploring a specific dimension deeper | Writing DNA Discovery (Dimension Deep-Dive) |
+| Ghost writer keeps getting something wrong | Writing DNA Discovery (Refinement from Feedback) |
+| Your writing style has changed | Writing DNA Discovery (Evolution Update) |
+| Capturing voice for different context | Writing DNA Discovery (New Register) |
+| Need a first draft for a writing task | Ghost Writer |
+| Need blog post, essay, or newsletter draft | Ghost Writer |
+| Need LinkedIn post or Twitter thread | Ghost Writer |
+
+## Integration Notes
+
+The Writing Skills pipeline is designed to be self-contained but can integrate with other workflows:
+
+- **Research phase**: Gather materials before running Ghost Writer. The skill will ask about research sufficiency and can work with provided context.
+- **Editing phase**: Drafts from Ghost Writer are starting points. Apply your editing process as you normally would.
+- **Series writing**: Provide Ghost Writer with prior pieces to maintain continuity across a series.
+
+## Best Practices
+
+1. **Be honest during discovery**: The DNA document captures your actual voice. If you want to evolve your voice, note that explicitly so the skill can capture both current patterns and aspirational direction.
+
+2. **Provide diverse samples**: Include pieces from different moods, topics, and lengths to capture the full range of your voice.
+
+3. **Engage in the interview**: The collaborative dialogue surfaces patterns you may not consciously recognize. Push back when something does not feel right.
+
+4. **Read drafts aloud**: Voice patterns are often most apparent when you hear them. Read Ghost Writer output aloud to spot what feels "off."
+
+5. **Give specific feedback**: "This doesn't sound like me" is less useful than "I would never start a paragraph with 'However'" or "These sentences are too long for my voice."
+
+6. **Iterate on the DNA document**: The profile improves with use. Return to DNA Discovery when you notice patterns the ghost writer consistently misses.

--- a/docs/skills/writing/index.md
+++ b/docs/skills/writing/index.md
@@ -113,7 +113,7 @@ The DNA Discovery skill analyzes multiple dimensions of voice:
 - Punctuation Personality: em-dashes, semicolons, parentheses, comma density
 - Word Choice: vocabulary level, favorites, avoided words
 - Tone and Temperature: warm/cool, formal/casual, confident/hedging
-- Reader Relationship: first person presence, direct address, authority stance
+- Reader Relationship: first-person presence, direct address, authority stance
 
 **Extended Dimensions** (as relevant):
 - Opening Moves: how pieces begin

--- a/docs/skills/writing/writing-dna-discovery.md
+++ b/docs/skills/writing/writing-dna-discovery.md
@@ -1,0 +1,340 @@
+# Writing DNA Discovery
+
+> Capture a writer's voice DNA through collaborative interview and sample analysis. Use when someone wants to document their writing voice for use with a ghost writer skill. Produces a Voice DNA Document with patterns, anti-patterns, and actionable guidance. Handles one register/mode per session, supports refinement over time.
+
+## Overview
+
+Writing DNA Discovery captures the "genetic code" of your writing voice. Rather than relying on vague descriptions like "conversational" or "professional," this skill systematically analyzes what makes your writing recognizably yours: sentence rhythm patterns, punctuation personality, word choice tendencies, tone temperature, and the relationship you build with readers.
+
+The process combines two approaches. When you provide writing samples, the skill analyzes them for distinctive patterns, identifying the 3-5 characteristics that jump out as uniquely yours. Through collaborative interview, you refine and validate these observations, adding context and surfacing choices you make consciously. The result is a Voice DNA Document that serves as actionable guidance for the Ghost Writer skill.
+
+This is genuine intellectual partnership, not extraction or interrogation. The skill contributes observations, challenges vague answers, and pushes for specificity. But you are the expert on your own voice. The skill helps you articulate and document what you already know instinctively.
+
+## Quick Start
+
+### Prerequisites
+
+- 3-5 writing samples that represent your authentic voice (optional but recommended)
+- Clear sense of which register/mode you want to capture (blog, fiction, technical, etc.)
+- Time for collaborative conversation (initial sessions typically take 30-60 minutes)
+
+### Basic Usage
+
+**For Initial Discovery:**
+
+```
+I want to capture my writing voice. I write blog posts about technology.
+
+Here are some samples:
+[Paste 3-5 representative pieces]
+```
+
+The skill will analyze your samples, share initial observations, and begin the collaborative interview process.
+
+**For Returning Users:**
+
+```
+I want to refine my Voice DNA Document. The ghost writer keeps
+using em-dashes too much - I rarely use them.
+
+[Paste current Voice DNA Document]
+```
+
+The skill will review your document, incorporate the feedback, and update the relevant sections.
+
+## Features
+
+### Voice Dimension Framework
+
+The skill captures 11+ dimensions of voice, deployed intelligently based on what is most distinctive for your writing:
+
+**Core Dimensions (always explored):**
+
+| Dimension | What It Captures |
+|-----------|------------------|
+| Sentence Rhythm | Length variation, internal structure, emphasis placement, cadence |
+| Punctuation Personality | Em-dashes, semicolons, parentheses, comma density, exclamation points |
+| Word Choice | Vocabulary level, Anglo-Saxon vs. Latinate, favorites, avoided words |
+| Tone and Temperature | Warm/cool, formal/casual, confident/hedging, measured/enthusiastic |
+| Reader Relationship | First person presence, direct address, assumed knowledge, authority stance |
+
+**Extended Dimensions (surfaced as relevant):**
+
+| Dimension | What It Captures |
+|-----------|------------------|
+| Opening Moves | How you begin pieces: hooks, questions, scene-setting, in media res |
+| Closing Moves | How you end: callbacks, questions, definitive statements, quiet landings |
+| Structural Patterns | Paragraph construction, transitions, section organization |
+| Confidence/Hedging | "Perhaps" vs. direct assertion, qualifier density, uncertainty handling |
+| Humor Approach | If present: dry wit, self-deprecation, wordplay, sarcasm, or absent |
+| Signature Elements | Distinctive moves, pet phrases, characteristic tics |
+
+**Register-Specific Dimensions:**
+
+- **Fiction**: Narrative distance, dialogue style, description density, interiority access
+- **Non-Fiction/Essays**: Argument structure, evidence presentation, concession patterns
+- **Blog/Casual**: Hook patterns, personal anecdote integration, call-to-action style
+- **Technical**: Instruction structure, example density, assumed reader competence
+
+### Discovery Techniques
+
+Beyond standard Q&A, the skill uses specialized techniques to surface voice:
+
+- **Comparative Choices**: "Would you write 'He walked into the room' or 'He stepped into the room'?"
+- **Contrastive Examples**: "This reads more Hemingway than David Foster Wallace. Where are you on that spectrum?"
+- **Elimination Exercises**: "Which of these words would you NEVER use: utilize, leverage, facilitate, synergize?"
+- **Completion Prompts**: Give a sentence starter; see how you naturally finish it
+- **Rewrite Exercises**: Transform generic AI-sounding text into your voice
+
+### Anti-Pattern Capture
+
+What you do not do is as important as what you do. The skill captures:
+
+- Words and phrases you never use
+- Structures and tones that would feel "off"
+- AI patterns to actively suppress (common tells that would make output sound machine-generated)
+
+### Session Types
+
+| Type | When to Use | Approach |
+|------|-------------|----------|
+| Initial Discovery | First time capturing your voice | Full discovery flow with samples and interview |
+| Sample Addition | Adding new samples to existing profile | Analyze new samples, compare to profile, integrate |
+| Dimension Deep-Dive | Want to go deeper on a specific aspect | Focus on single dimension in detail |
+| Refinement from Feedback | Ghost writer keeps getting something wrong | Convert feedback into explicit anti-patterns |
+| Evolution Update | Writing style has changed over time | Compare old vs. new samples, update profile |
+| New Register | Capturing voice for different context | New discovery for different mode |
+
+## Workflow
+
+### Phase 1: Start
+
+**For New Users:**
+1. Identify the register/mode to capture (blog, fiction, technical, etc.)
+2. Share writing samples if available
+3. Clarify the goal (general capture vs. specific project)
+4. Discuss influences or writers you identify with
+
+**For Returning Users:**
+1. Provide current Voice DNA Document
+2. Review what is developed vs. needs depth
+3. Clarify what brings you back (new samples, feedback, evolution, deep dive)
+4. Focus on specific areas to address
+
+### Phase 2: Analysis and Interview
+
+When you provide samples, the skill:
+
+1. **Initial Scan**: Reads samples and identifies the 3-5 most distinctive patterns
+2. **Shares Observations**: Presents findings with specific examples from your text
+3. **Dialogue and Refinement**: You confirm, adjust, or add context
+4. **Probes Deeper**: Asks targeted questions based on what emerged
+5. **Synthesizes**: Updates the DNA document at meaningful milestones
+
+The skill maintains these behaviors throughout:
+- **One question at a time**: Never overwhelms with multiple questions
+- **Proactive observations with reasoning**: Explains why patterns matter
+- **Contradiction flagging**: Surfaces inconsistencies for clarification
+- **Gap identification**: Notes dimensions that need more exploration
+
+### Phase 3: End
+
+1. **Summary**: Current state of the profile, what is developed vs. needs depth
+2. **Readiness Assessment**: Where the profile sits on the readiness scale
+3. **Next Steps**: What to tackle next time, or signal readiness for ghost writer
+4. **Overnight Question**: Something to notice before next session
+
+Example overnight question:
+> "Between now and next time, notice a piece of writing - yours or someone else's - that makes you think 'that is exactly how I would/wouldn't say that.' Bring it back."
+
+## Inputs and Outputs
+
+### Inputs
+
+| Input | Required | Description |
+|-------|----------|-------------|
+| Writing samples | Recommended | 3-5 pieces representing your authentic voice |
+| Register/mode | Required | Blog, fiction, technical, newsletter, etc. |
+| Existing DNA document | For return sessions | Current Voice DNA Document to refine |
+| Feedback | For refinement sessions | What the ghost writer gets wrong |
+
+### Outputs
+
+**Voice DNA Document** containing:
+
+- **Quick Reference**: Core temperature, sentence signature, distinctive moves, never-dos
+- **Voice Profile**: Dimension-by-dimension analysis with status indicators and examples
+- **Exemplar Passages**: Annotated excerpts demonstrating patterns in action
+- **Anti-Patterns**: What to avoid with reasoning, including AI patterns to suppress
+- **Ghost Writer Briefing**: Do This, Don't Do This, When Uncertain rules
+- **Profile Metadata**: Readiness level, confidence assessment per dimension, gaps
+- **Session History**: Record of discovery sessions for continuity
+
+## Best Practices
+
+### Sample Selection
+
+- Choose writing you are proud of, not heavily edited pieces
+- Include variety: different topics, moods, lengths
+- Avoid collaborative or ghostwritten work unless you can identify your contributions
+- Select pieces that feel most "you," even if they break conventional rules
+
+### During Discovery
+
+- Push back when observations do not feel right: "Actually, that was unusual for me"
+- Provide context: "I was trying something different in that piece"
+- Be honest about aspirational vs. actual voice
+- Share what you consciously avoid and why
+
+### Document Maintenance
+
+- Return for refinement when ghost writer output reveals gaps
+- Update after significant shifts in your writing practice
+- Create separate documents for genuinely different registers
+- Version the document when significant changes occur
+
+### Readiness Assessment
+
+Do not stop too early. Minimum Viable readiness requires:
+
+- [ ] At least 3-5 strong patterns identified with examples
+- [ ] Clear sense of tone/emotional temperature
+- [ ] Key anti-patterns documented
+- [ ] Your validation ("yes, that is me")
+
+Solid readiness adds:
+
+- [ ] Multiple dimensions developed with confidence
+- [ ] Exemplar passages annotated
+- [ ] Ghost Writer Briefing section complete
+- [ ] Anti-patterns with reasoning
+- [ ] Stress-tested against your instincts
+
+## Integration
+
+### Pipeline Position
+
+Writing DNA Discovery is the upstream skill in the Writing Pipeline. It produces the Voice DNA Document that Ghost Writer consumes.
+
+```
+Writing DNA Discovery --> Voice DNA Document --> Ghost Writer --> Drafts
+```
+
+### Upstream Skills
+
+None required. Writing DNA Discovery is typically the entry point to the writing pipeline.
+
+### Downstream Skills
+
+- **Ghost Writer**: Consumes the Voice DNA Document to generate drafts
+
+### Cross-Pipeline Integration
+
+- Voice DNA Documents can inform any writing task, not just Ghost Writer
+- The document serves as reference for manual writing and editing
+- Patterns can guide feedback to human editors or collaborators
+
+## Examples
+
+### Example 1: Initial Discovery Session
+
+**User Input:**
+```
+I write a newsletter about product management. Here are three recent issues:
+
+[Sample 1: 800-word essay on roadmapping]
+[Sample 2: 600-word piece on stakeholder communication]
+[Sample 3: 1000-word deep dive on metrics]
+```
+
+**Skill Response:**
+> Here is what I am noticing about your writing:
+>
+> **Sentence Rhythm**: You favor short, punchy sentences (8-12 words) punctuated by occasional longer explanatory sentences (20-25 words). The short sentences carry your main points; the longer ones provide context. Example from your roadmapping piece: "Roadmaps are not plans. They're communication tools."
+>
+> **Punctuation**: Heavy em-dash user. You deploy them for dramatic pauses rather than parenthetical insertions. I count 12 em-dashes across these three pieces, always singles, never pairs.
+>
+> **Opening Pattern**: You start with a bold claim that challenges conventional wisdom. All three pieces open with a provocative statement: "Roadmaps are lies," "Your stakeholders don't care about your features," "Most metrics meetings are theater."
+>
+> Before I continue: Does this feel accurate? And that opening pattern - is it intentional or something you do naturally?
+
+### Example 2: Refinement from Feedback
+
+**User Input:**
+```
+The ghost writer keeps adding phrases like "It's important to note" and
+"In today's fast-paced environment." I would never write those.
+
+[Existing DNA Document]
+```
+
+**Skill Response:**
+> Got it. These are classic AI patterns that definitely don't fit your voice. Let me add them to your Anti-Patterns section:
+>
+> **AI Patterns to Suppress** (updated):
+> - "It's important to note/remember" - hedging phrase; you assert directly
+> - "In today's [adjective] [noun]" - throat-clearing; you start with substance
+> - "As we navigate..." - corporate-speak; you use plain language
+>
+> I've also added these to your "Don't Do This" list in the Ghost Writer Briefing.
+>
+> Are there other phrases from recent ghost writer output that felt wrong? I want to make sure we catch the full pattern.
+
+### Example 3: New Register
+
+**User Input:**
+```
+I have my blog voice captured. Now I want to capture my fiction voice -
+I'm working on a mystery novel.
+
+[Existing blog Voice DNA Document]
+```
+
+**Skill Response:**
+> Fiction is a different register, so we'll create a separate Voice DNA Document for your mystery writing. Your blog voice may or may not transfer - we'll discover that together.
+>
+> Do you have fiction samples to share? Even drafts or fragments would help. And tell me about your fiction influences - which mystery writers do you admire, and which do you want to sound nothing like?
+
+## Reference Files
+
+The skill can load these references as needed during discovery:
+
+| File | Purpose |
+|------|---------|
+| `references/anti-ai-patterns.md` | Common AI tells to suppress |
+| `references/voice-dimension-catalog.md` | Deep exploration of each dimension |
+| `references/interview-question-bank.md` | Structured discovery questions |
+| `references/sample-analysis-guide.md` | Systematic sample analysis approach |
+| `references/dna-document-examples.md` | Examples of well-developed profiles |
+| `references/failure-patterns.md` | Signs that a profile is weak |
+
+## Edge Cases
+
+### Aspirational vs. Actual Voice
+
+If there is a gap between how you describe your ideal voice and what appears in samples:
+> "I'm noticing a gap between how you describe your ideal voice and what I see in these samples. Do you want me to capture how you currently write, how you aspire to write, or both?"
+
+The document can capture both, noting which is which.
+
+### Limited Samples
+
+With only one short piece:
+- Acknowledge lower confidence
+- Lean more heavily on interview
+- Note which patterns are confirmed vs. tentative
+- Flag dimensions that need more sample data
+
+### Inconsistent Samples
+
+If samples show conflicting patterns:
+- Is this multiple registers? (Capture separately)
+- Is this evolution? (Capture current preference)
+- Is this situational? (Document when each applies)
+
+### Edited/Collaborative Work
+
+If samples may have been edited by others:
+- Ask about editorial involvement
+- Focus on patterns you confirm as "yours"
+- Note uncertainty where relevant

--- a/docs/skills/writing/writing-dna-discovery.md
+++ b/docs/skills/writing/writing-dna-discovery.md
@@ -22,7 +22,7 @@ This is genuine intellectual partnership, not extraction or interrogation. The s
 
 **For Initial Discovery:**
 
-```
+```text
 I want to capture my writing voice. I write blog posts about technology.
 
 Here are some samples:
@@ -33,7 +33,7 @@ The skill will analyze your samples, share initial observations, and begin the c
 
 **For Returning Users:**
 
-```
+```text
 I want to refine my Voice DNA Document. The ghost writer keeps
 using em-dashes too much - I rarely use them.
 

--- a/ebook-factory/README.md
+++ b/ebook-factory/README.md
@@ -1,9 +1,17 @@
-# The Ebook Factory: Complete Reference Guide
+# The Ebook Factory
+
+A suite of Claude skills designed specifically for ebook creation—shorter, concentrated solutions optimized for speed-to-value.
+
+📚 **[View Full Documentation](https://robertguss.github.io/claude-skills/skills/ebook-factory/)**
+
+---
+
+## Reference Guide
 
 **Purpose:** This document captures the complete vision, philosophy, and specifications for a suite of Claude skills designed specifically for ebook creation. Use this to brief future Claude sessions when building individual skills.
 
-**Author:** Robert Guss  
-**Created:** December 30, 2024  
+**Author:** Robert Guss
+**Created:** December 30, 2024
 **Last Updated:** December 31, 2024
 
 ---

--- a/justfile
+++ b/justfile
@@ -51,4 +51,4 @@ list-skills:
 
 # Clean build artifacts
 clean:
-    rm -rf dist/ site/ .venv/
+    rm -rf dist/ site/

--- a/justfile
+++ b/justfile
@@ -1,0 +1,54 @@
+# Claude Skills Justfile
+# Run `just` to see available commands
+
+# Default command - show help
+default:
+    @just --list
+
+# Install all dependencies including docs
+install:
+    uv sync --all-extras
+
+# Install only core dependencies (no docs)
+install-core:
+    uv sync
+
+# ─────────────────────────────────────────────────────────────
+# Documentation
+# ─────────────────────────────────────────────────────────────
+
+# Serve documentation locally at http://localhost:8000
+docs-serve:
+    uv run mkdocs serve
+
+# Build documentation to site/ directory
+docs-build:
+    uv run mkdocs build
+
+# Deploy documentation to GitHub Pages
+docs-deploy:
+    uv run mkdocs gh-deploy
+
+# ─────────────────────────────────────────────────────────────
+# Skills
+# ─────────────────────────────────────────────────────────────
+
+# Package a single skill (e.g., just package brainstorm)
+package skill:
+    uv run python build.py {{skill}}
+
+# Package all skills
+package-all:
+    uv run python build.py --all
+
+# List all available skills
+list-skills:
+    uv run python build.py --list
+
+# ─────────────────────────────────────────────────────────────
+# Development
+# ─────────────────────────────────────────────────────────────
+
+# Clean build artifacts
+clean:
+    rm -rf dist/ site/ .venv/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,127 @@
+site_name: Claude Skills Documentation
+site_description: >-
+  Modular packages that extend Claude's capabilities with specialized
+  workflows, domain knowledge, and tools.
+site_url: https://robertguss.github.io/claude-skills/
+repo_url: https://github.com/robertguss/claude-skills
+repo_name: claude-skills
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    # Light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: deep purple
+      accent: amber
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    # Dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: deep purple
+      accent: amber
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.sections
+    - navigation.expand
+    - navigation.indexes
+    - navigation.top
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.tabs.link
+    - toc.follow
+
+  icon:
+    repo: fontawesome/brands/github
+
+nav:
+  - Home: index.md
+  - Getting Started:
+    - getting-started/index.md
+    - What Are Skills?: getting-started/what-are-skills.md
+    - Claude Code Setup: getting-started/installation-claude-code.md
+    - Claude.ai Setup: getting-started/installation-claude-ai.md
+    - Your First Skill: getting-started/your-first-skill.md
+  - Skills:
+    - skills/index.md
+    - Brainstorm: skills/brainstorm/index.md
+    - Non-Fiction Book Factory:
+      - skills/non-fiction-book-factory/index.md
+      - Book Ideation: skills/non-fiction-book-factory/book-ideation.md
+      - Book Idea Validator: skills/non-fiction-book-factory/book-idea-validator.md
+      - Book Market Research: skills/non-fiction-book-factory/book-market-research.md
+      - Book Architect: skills/non-fiction-book-factory/book-architect.md
+      - Book Research Assistant: skills/non-fiction-book-factory/book-research-assistant.md
+      - Chapter Architect: skills/non-fiction-book-factory/chapter-architect.md
+    - Ebook Factory:
+      - skills/ebook-factory/index.md
+      - Ebook Discovery: skills/ebook-factory/ebook-discovery.md
+      - Ebook Concept Development: skills/ebook-factory/ebook-concept-development.md
+    - Writing:
+      - skills/writing/index.md
+      - Writing DNA Discovery: skills/writing/writing-dna-discovery.md
+      - Ghost Writer: skills/writing/ghost-writer.md
+  - Developer Guide:
+    - developer-guide/index.md
+    - Skill Anatomy: developer-guide/skill-anatomy.md
+    - Writing SKILL.md: developer-guide/writing-skill-md.md
+    - References & Assets: developer-guide/references-and-assets.md
+    - Building & Packaging: developer-guide/building-and-packaging.md
+    - Contributing: developer-guide/contributing.md
+  - Concepts:
+    - concepts/index.md
+    - Pipelines: concepts/pipelines.md
+    - Session Continuity: concepts/session-continuity.md
+    - Handoffs: concepts/handoffs.md
+    - Modes & Registers: concepts/modes-and-registers.md
+  - Reference:
+    - reference/index.md
+    - Skill Catalog: reference/skill-catalog.md
+    - Build Commands: reference/build-commands.md
+
+plugins:
+  - search
+  - tags
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - attr_list
+  - md_in_html
+  - toc:
+      permalink: true
+      toc_depth: 3
+  - tables
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/robertguss/claude-skills
+
+  generator: false
+
+copyright: Personal use. Modify freely.

--- a/non-fiction-book-factory/README.md
+++ b/non-fiction-book-factory/README.md
@@ -2,6 +2,8 @@
 
 A suite of Claude skills that replicate the traditional publishing infrastructure for nonfiction book creation. Each skill specializes in one phase of the book development process, handing off structured output to the next.
 
+📚 **[View Full Documentation](https://robertguss.github.io/claude-skills/skills/non-fiction-book-factory/)**
+
 ## Pipeline Overview
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,16 @@
 [project]
 name = "claude-skills"
 version = "0.1.0"
-description = "Add your description here"
+description = "Custom skills that extend Claude's capabilities with specialized workflows and domain knowledge"
 readme = "README.md"
 requires-python = ">=3.13"
-dependencies = []
+dependencies = [
+    "pyyaml>=6.0",
+]
+
+[project.optional-dependencies]
+docs = [
+    "mkdocs>=1.5.0",
+    "mkdocs-material>=9.5.0",
+    "pymdown-extensions>=10.0",
+]

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,3 @@
+mkdocs>=1.5.0
+mkdocs-material>=9.5.0
+pymdown-extensions>=10.0

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,0 @@
-mkdocs>=1.5.0
-mkdocs-material>=9.5.0
-pymdown-extensions>=10.0

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,465 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"
+
+[[package]]
+name = "babel"
+version = "2.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/6b/d52e42361e1aa00709585ecc30b3f9684b3ab62530771402248b1b1d6240/babel-2.17.0.tar.gz", hash = "sha256:0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d", size = 9951852, upload-time = "2025-02-01T15:17:41.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b8/3fe70c75fe32afc4bb507f75563d39bc5642255d1d94f1f23604725780bf/babel-2.17.0-py3-none-any.whl", hash = "sha256:4d0b53093fdfb4b21c92b5213dba5a1b23885afa8383709427046b21c366e5f2", size = 10182537, upload-time = "2025-02-01T15:17:37.39Z" },
+]
+
+[[package]]
+name = "backrefs"
+version = "6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/e3/bb3a439d5cb255c4774724810ad8073830fac9c9dee123555820c1bcc806/backrefs-6.1.tar.gz", hash = "sha256:3bba1749aafe1db9b915f00e0dd166cba613b6f788ffd63060ac3485dc9be231", size = 7011962, upload-time = "2025-11-15T14:52:08.323Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ee/c216d52f58ea75b5e1841022bbae24438b19834a29b163cb32aa3a2a7c6e/backrefs-6.1-py310-none-any.whl", hash = "sha256:2a2ccb96302337ce61ee4717ceacfbf26ba4efb1d55af86564b8bbaeda39cac1", size = 381059, upload-time = "2025-11-15T14:51:59.758Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9a/8da246d988ded941da96c7ed945d63e94a445637eaad985a0ed88787cb89/backrefs-6.1-py311-none-any.whl", hash = "sha256:e82bba3875ee4430f4de4b6db19429a27275d95a5f3773c57e9e18abc23fd2b7", size = 392854, upload-time = "2025-11-15T14:52:01.194Z" },
+    { url = "https://files.pythonhosted.org/packages/37/c9/fd117a6f9300c62bbc33bc337fd2b3c6bfe28b6e9701de336b52d7a797ad/backrefs-6.1-py312-none-any.whl", hash = "sha256:c64698c8d2269343d88947c0735cb4b78745bd3ba590e10313fbf3f78c34da5a", size = 398770, upload-time = "2025-11-15T14:52:02.584Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/95/7118e935b0b0bd3f94dfec2d852fd4e4f4f9757bdb49850519acd245cd3a/backrefs-6.1-py313-none-any.whl", hash = "sha256:4c9d3dc1e2e558965202c012304f33d4e0e477e1c103663fd2c3cc9bb18b0d05", size = 400726, upload-time = "2025-11-15T14:52:04.093Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/72/6296bad135bfafd3254ae3648cd152980a424bd6fed64a101af00cc7ba31/backrefs-6.1-py314-none-any.whl", hash = "sha256:13eafbc9ccd5222e9c1f0bec563e6d2a6d21514962f11e7fc79872fd56cbc853", size = 412584, upload-time = "2025-11-15T14:52:05.233Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e3/a4fa1946722c4c7b063cc25043a12d9ce9b4323777f89643be74cef2993c/backrefs-6.1-py39-none-any.whl", hash = "sha256:a9e99b8a4867852cad177a6430e31b0f6e495d65f8c6c134b68c14c3c95bf4b0", size = 381058, upload-time = "2025-11-15T14:52:06.698Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2025.11.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/8c/58f469717fa48465e4a50c014a0400602d3c437d7c0c468e17ada824da3a/certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316", size = 160538, upload-time = "2025-11-12T02:54:51.517Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/7d/9bc192684cea499815ff478dfcdc13835ddf401365057044fb721ec6bddb/certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b", size = 159438, upload-time = "2025-11-12T02:54:49.735Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/69/33ddede1939fdd074bce5434295f38fae7136463422fe4fd3e0e89b98062/charset_normalizer-3.4.4.tar.gz", hash = "sha256:94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a", size = 129418, upload-time = "2025-10-14T04:42:32.879Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/45/4b3a1239bbacd321068ea6e7ac28875b03ab8bc0aa0966452db17cd36714/charset_normalizer-3.4.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e1f185f86a6f3403aa2420e815904c67b2f9ebc443f045edd0de921108345794", size = 208091, upload-time = "2025-10-14T04:41:13.346Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/62/73a6d7450829655a35bb88a88fca7d736f9882a27eacdca2c6d505b57e2e/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b39f987ae8ccdf0d2642338faf2abb1862340facc796048b604ef14919e55ed", size = 147936, upload-time = "2025-10-14T04:41:14.461Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c5/adb8c8b3d6625bef6d88b251bbb0d95f8205831b987631ab0c8bb5d937c2/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3162d5d8ce1bb98dd51af660f2121c55d0fa541b46dff7bb9b9f86ea1d87de72", size = 144180, upload-time = "2025-10-14T04:41:15.588Z" },
+    { url = "https://files.pythonhosted.org/packages/91/ed/9706e4070682d1cc219050b6048bfd293ccf67b3d4f5a4f39207453d4b99/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:81d5eb2a312700f4ecaa977a8235b634ce853200e828fbadf3a9c50bab278328", size = 161346, upload-time = "2025-10-14T04:41:16.738Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/0d/031f0d95e4972901a2f6f09ef055751805ff541511dc1252ba3ca1f80cf5/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5bd2293095d766545ec1a8f612559f6b40abc0eb18bb2f5d1171872d34036ede", size = 158874, upload-time = "2025-10-14T04:41:17.923Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/83/6ab5883f57c9c801ce5e5677242328aa45592be8a00644310a008d04f922/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a8a8b89589086a25749f471e6a900d3f662d1d3b6e2e59dcecf787b1cc3a1894", size = 153076, upload-time = "2025-10-14T04:41:19.106Z" },
+    { url = "https://files.pythonhosted.org/packages/75/1e/5ff781ddf5260e387d6419959ee89ef13878229732732ee73cdae01800f2/charset_normalizer-3.4.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc7637e2f80d8530ee4a78e878bce464f70087ce73cf7c1caf142416923b98f1", size = 150601, upload-time = "2025-10-14T04:41:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/57/71be810965493d3510a6ca79b90c19e48696fb1ff964da319334b12677f0/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f8bf04158c6b607d747e93949aa60618b61312fe647a6369f88ce2ff16043490", size = 150376, upload-time = "2025-10-14T04:41:21.398Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/d5/c3d057a78c181d007014feb7e9f2e65905a6c4ef182c0ddf0de2924edd65/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:554af85e960429cf30784dd47447d5125aaa3b99a6f0683589dbd27e2f45da44", size = 144825, upload-time = "2025-10-14T04:41:22.583Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8c/d0406294828d4976f275ffbe66f00266c4b3136b7506941d87c00cab5272/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:74018750915ee7ad843a774364e13a3db91682f26142baddf775342c3f5b1133", size = 162583, upload-time = "2025-10-14T04:41:23.754Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/24/e2aa1f18c8f15c4c0e932d9287b8609dd30ad56dbe41d926bd846e22fb8d/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c0463276121fdee9c49b98908b3a89c39be45d86d1dbaa22957e38f6321d4ce3", size = 150366, upload-time = "2025-10-14T04:41:25.27Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/5b/1e6160c7739aad1e2df054300cc618b06bf784a7a164b0f238360721ab86/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:362d61fd13843997c1c446760ef36f240cf81d3ebf74ac62652aebaf7838561e", size = 160300, upload-time = "2025-10-14T04:41:26.725Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/10/f882167cd207fbdd743e55534d5d9620e095089d176d55cb22d5322f2afd/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9a26f18905b8dd5d685d6d07b0cdf98a79f3c7a918906af7cc143ea2e164c8bc", size = 154465, upload-time = "2025-10-14T04:41:28.322Z" },
+    { url = "https://files.pythonhosted.org/packages/89/66/c7a9e1b7429be72123441bfdbaf2bc13faab3f90b933f664db506dea5915/charset_normalizer-3.4.4-cp313-cp313-win32.whl", hash = "sha256:9b35f4c90079ff2e2edc5b26c0c77925e5d2d255c42c74fdb70fb49b172726ac", size = 99404, upload-time = "2025-10-14T04:41:29.95Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/26/b9924fa27db384bdcd97ab83b4f0a8058d96ad9626ead570674d5e737d90/charset_normalizer-3.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:b435cba5f4f750aa6c0a0d92c541fb79f69a387c91e61f1795227e4ed9cece14", size = 107092, upload-time = "2025-10-14T04:41:31.188Z" },
+    { url = "https://files.pythonhosted.org/packages/af/8f/3ed4bfa0c0c72a7ca17f0380cd9e4dd842b09f664e780c13cff1dcf2ef1b/charset_normalizer-3.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:542d2cee80be6f80247095cc36c418f7bddd14f4a6de45af91dfad36d817bba2", size = 100408, upload-time = "2025-10-14T04:41:32.624Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/35/7051599bd493e62411d6ede36fd5af83a38f37c4767b92884df7301db25d/charset_normalizer-3.4.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:da3326d9e65ef63a817ecbcc0df6e94463713b754fe293eaa03da99befb9a5bd", size = 207746, upload-time = "2025-10-14T04:41:33.773Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9a/97c8d48ef10d6cd4fcead2415523221624bf58bcf68a802721a6bc807c8f/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8af65f14dc14a79b924524b1e7fffe304517b2bff5a58bf64f30b98bbc5079eb", size = 147889, upload-time = "2025-10-14T04:41:34.897Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bf/979224a919a1b606c82bd2c5fa49b5c6d5727aa47b4312bb27b1734f53cd/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:74664978bb272435107de04e36db5a9735e78232b85b77d45cfb38f758efd33e", size = 143641, upload-time = "2025-10-14T04:41:36.116Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/33/0ad65587441fc730dc7bd90e9716b30b4702dc7b617e6ba4997dc8651495/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:752944c7ffbfdd10c074dc58ec2d5a8a4cd9493b314d367c14d24c17684ddd14", size = 160779, upload-time = "2025-10-14T04:41:37.229Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ed/331d6b249259ee71ddea93f6f2f0a56cfebd46938bde6fcc6f7b9a3d0e09/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d1f13550535ad8cff21b8d757a3257963e951d96e20ec82ab44bc64aeb62a191", size = 159035, upload-time = "2025-10-14T04:41:38.368Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ff/f6b948ca32e4f2a4576aa129d8bed61f2e0543bf9f5f2b7fc3758ed005c9/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ecaae4149d99b1c9e7b88bb03e3221956f68fd6d50be2ef061b2381b61d20838", size = 152542, upload-time = "2025-10-14T04:41:39.862Z" },
+    { url = "https://files.pythonhosted.org/packages/16/85/276033dcbcc369eb176594de22728541a925b2632f9716428c851b149e83/charset_normalizer-3.4.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cb6254dc36b47a990e59e1068afacdcd02958bdcce30bb50cc1700a8b9d624a6", size = 149524, upload-time = "2025-10-14T04:41:41.319Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/f2/6a2a1f722b6aba37050e626530a46a68f74e63683947a8acff92569f979a/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c8ae8a0f02f57a6e61203a31428fa1d677cbe50c93622b4149d5c0f319c1d19e", size = 150395, upload-time = "2025-10-14T04:41:42.539Z" },
+    { url = "https://files.pythonhosted.org/packages/60/bb/2186cb2f2bbaea6338cad15ce23a67f9b0672929744381e28b0592676824/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:47cc91b2f4dd2833fddaedd2893006b0106129d4b94fdb6af1f4ce5a9965577c", size = 143680, upload-time = "2025-10-14T04:41:43.661Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/a5/bf6f13b772fbb2a90360eb620d52ed8f796f3c5caee8398c3b2eb7b1c60d/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:82004af6c302b5d3ab2cfc4cc5f29db16123b1a8417f2e25f9066f91d4411090", size = 162045, upload-time = "2025-10-14T04:41:44.821Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c5/d1be898bf0dc3ef9030c3825e5d3b83f2c528d207d246cbabe245966808d/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2b7d8f6c26245217bd2ad053761201e9f9680f8ce52f0fcd8d0755aeae5b2152", size = 149687, upload-time = "2025-10-14T04:41:46.442Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/42/90c1f7b9341eef50c8a1cb3f098ac43b0508413f33affd762855f67a410e/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:799a7a5e4fb2d5898c60b640fd4981d6a25f1c11790935a44ce38c54e985f828", size = 160014, upload-time = "2025-10-14T04:41:47.631Z" },
+    { url = "https://files.pythonhosted.org/packages/76/be/4d3ee471e8145d12795ab655ece37baed0929462a86e72372fd25859047c/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:99ae2cffebb06e6c22bdc25801d7b30f503cc87dbd283479e7b606f70aff57ec", size = 154044, upload-time = "2025-10-14T04:41:48.81Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/6f/8f7af07237c34a1defe7defc565a9bc1807762f672c0fde711a4b22bf9c0/charset_normalizer-3.4.4-cp314-cp314-win32.whl", hash = "sha256:f9d332f8c2a2fcbffe1378594431458ddbef721c1769d78e2cbc06280d8155f9", size = 99940, upload-time = "2025-10-14T04:41:49.946Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/51/8ade005e5ca5b0d80fb4aff72a3775b325bdc3d27408c8113811a7cbe640/charset_normalizer-3.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:8a6562c3700cce886c5be75ade4a5db4214fda19fede41d9792d100288d8f94c", size = 107104, upload-time = "2025-10-14T04:41:51.051Z" },
+    { url = "https://files.pythonhosted.org/packages/da/5f/6b8f83a55bb8278772c5ae54a577f3099025f9ade59d0136ac24a0df4bde/charset_normalizer-3.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:de00632ca48df9daf77a2c65a484531649261ec9f25489917f09e455cb09ddb2", size = 100743, upload-time = "2025-10-14T04:41:52.122Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4c/925909008ed5a988ccbb72dcc897407e5d6d3bd72410d69e051fc0c14647/charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f", size = 53402, upload-time = "2025-10-14T04:42:31.76Z" },
+]
+
+[[package]]
+name = "claude-skills"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "pyyaml" },
+]
+
+[package.optional-dependencies]
+docs = [
+    { name = "mkdocs" },
+    { name = "mkdocs-material" },
+    { name = "pymdown-extensions" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.5.0" },
+    { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5.0" },
+    { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=10.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
+]
+provides-extras = ["docs"]
+
+[[package]]
+name = "click"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "ghp-import"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "markdown"
+version = "3.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/ab/7dd27d9d863b3376fcf23a5a13cb5d024aed1db46f963f1b5735ae43b3be/markdown-3.10.tar.gz", hash = "sha256:37062d4f2aa4b2b6b32aefb80faa300f82cc790cb949a35b8caede34f2b68c0e", size = 364931, upload-time = "2025-11-03T19:51:15.007Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/81/54e3ce63502cd085a0c556652a4e1b919c45a446bd1e5300e10c44c8c521/markdown-3.10-py3-none-any.whl", hash = "sha256:b5b99d6951e2e4948d939255596523444c0e677c669700b1d17aa4a8a464cb7c", size = 107678, upload-time = "2025-11-03T19:51:13.887Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mergedeep"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
+name = "mkdocs"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mergedeep" },
+    { name = "mkdocs-get-deps" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451, upload-time = "2024-08-30T12:24:05.054Z" },
+]
+
+[[package]]
+name = "mkdocs-get-deps"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mergedeep" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/f5/ed29cd50067784976f25ed0ed6fcd3c2ce9eb90650aa3b2796ddf7b6870b/mkdocs_get_deps-0.2.0.tar.gz", hash = "sha256:162b3d129c7fad9b19abfdcb9c1458a651628e4b1dea628ac68790fb3061c60c", size = 10239, upload-time = "2023-11-20T17:51:09.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/d4/029f984e8d3f3b6b726bd33cafc473b75e9e44c0f7e80a5b29abc466bdea/mkdocs_get_deps-0.2.0-py3-none-any.whl", hash = "sha256:2bf11d0b133e77a0dd036abeeb06dec8775e46efa526dc70667d8863eefc6134", size = 9521, upload-time = "2023-11-20T17:51:08.587Z" },
+]
+
+[[package]]
+name = "mkdocs-material"
+version = "9.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "backrefs" },
+    { name = "colorama" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "mkdocs" },
+    { name = "mkdocs-material-extensions" },
+    { name = "paginate" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/e2/2ffc356cd72f1473d07c7719d82a8f2cbd261666828614ecb95b12169f41/mkdocs_material-9.7.1.tar.gz", hash = "sha256:89601b8f2c3e6c6ee0a918cc3566cb201d40bf37c3cd3c2067e26fadb8cce2b8", size = 4094392, upload-time = "2025-12-18T09:49:00.308Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/32/ed071cb721aca8c227718cffcf7bd539620e9799bbf2619e90c757bfd030/mkdocs_material-9.7.1-py3-none-any.whl", hash = "sha256:3f6100937d7d731f87f1e3e3b021c97f7239666b9ba1151ab476cabb96c60d5c", size = 9297166, upload-time = "2025-12-18T09:48:56.664Z" },
+]
+
+[[package]]
+name = "mkdocs-material-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "paginate"
+version = "0.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/46/68dde5b6bc00c1296ec6466ab27dddede6aec9af1b99090e1107091b3b84/paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945", size = 19252, upload-time = "2024-08-25T14:17:24.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591", size = 13746, upload-time = "2024-08-25T14:17:22.55Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/86/0248f086a84f01b37aaec0fa567b397df1a119f73c16f6c7a9aac73ea309/platformdirs-4.5.1.tar.gz", hash = "sha256:61d5cdcc6065745cdd94f0f878977f8de9437be93de97c1c12f853c9c0cdcbda", size = 21715, upload-time = "2025-12-05T13:52:58.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/28/3bfe2fa5a7b9c46fe7e13c97bda14c895fb10fa2ebf1d0abb90e0cea7ee1/platformdirs-4.5.1-py3-none-any.whl", hash = "sha256:d03afa3963c806a9bed9d5125c8f4cb2fdaf74a55ab60e5d59b3fde758104d31", size = 18731, upload-time = "2025-12-05T13:52:56.823Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pymdown-extensions"
+version = "10.20"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/35/e3814a5b7df295df69d035cfb8aab78b2967cdf11fcfae7faed726b66664/pymdown_extensions-10.20.tar.gz", hash = "sha256:5c73566ab0cf38c6ba084cb7c5ea64a119ae0500cce754ccb682761dfea13a52", size = 852774, upload-time = "2025-12-31T19:59:42.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/10/47caf89cbb52e5bb764696fd52a8c591a2f0e851a93270c05a17f36000b5/pymdown_extensions-10.20-py3-none-any.whl", hash = "sha256:ea9e62add865da80a271d00bfa1c0fa085b20d133fb3fc97afdc88e682f60b2f", size = 268733, upload-time = "2025-12-31T19:59:40.652Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "pyyaml-env-tag"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.32.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/24/a2a2ed9addd907787d7aa0355ba36a6cadf1768b934c652ea78acbd59dcd/urllib3-2.6.2.tar.gz", hash = "sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797", size = 432930, upload-time = "2025-12-11T15:56:40.252Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/b9/4095b668ea3678bf6a0af005527f39de12fb026516fb3df17495a733b7f8/urllib3-2.6.2-py3-none-any.whl", hash = "sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd", size = 131182, upload-time = "2025-12-11T15:56:38.584Z" },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480, upload-time = "2024-11-01T14:06:42.952Z" },
+    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451, upload-time = "2024-11-01T14:06:45.084Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057, upload-time = "2024-11-01T14:06:47.324Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]

--- a/writing/README.md
+++ b/writing/README.md
@@ -2,6 +2,8 @@
 
 A pipeline for capturing and replicating a writer's authentic voice. These skills work together: first discover your voice DNA, then use it to generate drafts that sound like you.
 
+📚 **[View Full Documentation](https://robertguss.github.io/claude-skills/skills/writing/)**
+
 ## The Workflow
 
 ```


### PR DESCRIPTION
## Summary
- Add MkDocs-based documentation site with comprehensive skill development guides
- Migrate docs dependencies to pyproject.toml for better dependency management
- Add justfile with commands for docs development, building, and deployment
- Include documentation for all existing skills (brainstorm, ebook-factory, non-fiction-book-factory, writing)

## Changes
- **New documentation structure**: Getting started guides, developer guides, concept explanations, and skill-specific documentation
- **Build tooling**: justfile with `docs`, `docs-build`, `docs-deploy`, and `clean` commands
- **Dependency management**: Added mkdocs, mkdocs-material, and related plugins to pyproject.toml

## Test plan
- [ ] Run `just docs` to verify local documentation server works
- [ ] Run `just docs-build` to verify documentation builds successfully
- [ ] Review documentation pages for accuracy and completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Full documentation site launched: Getting Started, Concepts, Developer Guide, Reference, and a comprehensive Skill Catalog including Brainstorm, Non‑Fiction Book Factory, Ebook Factory, and Writing pipelines with per‑skill guides and tutorials.
  * Many new how‑to pages: installation for CLI and web, packaging/build reference, contributor guide, and detailed skill workflows.

* **Chores**
  * Added docs/site build configuration, CLI task runner entries, and packaging/build dependencies (pyyaml, MkDocs and Material theme).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->